### PR TITLE
Add aggregated cluster roles for users

### DIFF
--- a/baas-operator/Chart.yaml
+++ b/baas-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Backup as a Service Operator
 name: baas-operator
-version: 1.2.0
+version: 1.2.1
 appVersion: v0.1.3
 maintainers:
   - name: APPUiO Team

--- a/baas-operator/templates/clusterrole.yaml
+++ b/baas-operator/templates/clusterrole.yaml
@@ -50,4 +50,44 @@ rules:
   - roles
   verbs:
   - '*'
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+  name: {{ template "baas-operator.fullname" $ }}-edit
+  labels:
+    app: {{ template "baas-operator.name" $ }}
+    chart: {{ template "baas-operator.chart" $ }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    # Add these permissions to the "admin" and "edit" default roles.
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+rules:
+  - apiGroups:
+      - backup.appuio.ch
+    resources:
+      - "*"
+    verbs:
+      - "*"
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "baas-operator.fullname" $ }}-view
+  labels:
+    app: {{ template "baas-operator.name" $ }}
+    chart: {{ template "baas-operator.chart" $ }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    # Add these permissions to the "view" default role.
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+rules:
+  - apiGroups:
+      - backup.appuio.ch
+    resources:
+      - "*"
+    verbs:
+      - get
+      - list
+      - watch
 {{- end }}


### PR DESCRIPTION
For users to be able to manage the custom resources, new aggregated
cluster roles [1] are created.

[1] https://kubernetes.io/docs/reference/access-authn-authz/rbac/#aggregated-clusterroles