### PR TITLE
HelmQA integration

### DIFF
--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -7,7 +7,7 @@ echo "----> Deploying to $REPO_URL"
 
 GIT_REPO="$(git config remote.origin.url)"
 
-helm_status=$(curl --max-time 10 $HELMQA_URL=$REPO_URL | jq -r .status)
+helm_status=$(curl --max-time 10 "$HELMQA_URL=$REPO_URL" | jq -r .status)
 
 echo "###################################### $helm_status ######################################"
 

--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -7,18 +7,21 @@ echo "----> Deploying to $REPO_URL"
 
 GIT_REPO="$(git config remote.origin.url)"
 
-HELM_RESPONSE=$(curl --connect-timeout 5 "$HELMQA_URL=$GIT_REPO")
+HELMQA_RESPONSE=$(curl --connect-timeout 5 "$HELMQA_URL=$GIT_REPO")
 
-HELM_STATUS=$(echo "$HELM_RESPONSE" | jq -r .status)
-HELM_RESPONSE_CODE=$(echo "$HELM_RESPONSE" | jq -r .code)
-
-echo "-------------------> $HELM_STATUS"
-echo "-------------------> $HELM_RESPONSE_CODE"
-
-if [[ "$HELM_STATUS" == "fail" ]]; then
-	echo "HelmQA test failed. Check response"
-	echo "-------------> $HELM_RESPONSE"
-	exit 1
+if [[ $? != 28 ]]; then
+	TEST_STATUS=$(echo "$HELMQA_RESPONSE" | jq -r .status)
+        echo "-------------------> $TEST_STATUS"
+	
+	if [[ "$TEST_STATUS" == "fail" ]]; then
+		echo "HelmQA test failed. Check response"
+		echo "-------------> $HELMQA_RESPONSE"
+		exit 1
+	else 
+		echo "HelmQA test succeeded. No issues found"
+	fi
+else
+	echo "HelmQA connection failed. Timed out!"
 fi
 
 tmp="$(mktemp -d)"

--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -8,7 +8,7 @@ echo "----> Deploying to $REPO_URL"
 GIT_REPO="$(git config remote.origin.url)"
 
 HELMQA_RESPONSE=$(curl --connect-timeout 5 "$HELMQA_URL=$GIT_REPO")
-
+echo $?
 if [[ $? != 28 ]]; then
 	TEST_STATUS=$(echo "$HELMQA_RESPONSE" | jq -r .status)
         echo "-------------------> $TEST_STATUS"

--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -3,41 +3,46 @@ set -e
 
 # set to one of the following values
 # - don't use HelmQA: (empty)
-# - use HelmQA in SaaS mode: http://helmqa-zhaw-prod-demos.appuioapp.ch/livecheck?repo
-# - use HelmQA locally in Docker mode: http://127.0.0.1:5000/livecheck?repo
-HELMQA_URL=http://helmqa-zhaw-prod-demos.appuioapp.ch/livecheck?repo
+# - use HelmQA in SaaS mode: 'http://helmqa-zhaw-prod-demos.appuioapp.ch/livecheck?repo'
+# - use HelmQA locally in Docker mode: 'http://127.0.0.1:5000/livecheck?repo'
+HELMQA_URL='http://helmqa-zhaw-prod-demos.appuioapp.ch/livecheck?repo'
 REPO_URL="${REPO_URL:-https://charts.appuio.ch}"
 echo "----> Deploying to $REPO_URL"
 
 GIT_REPO="$(git config remote.origin.url)"
 
-if [ ! -z $HELMQA_URL ]; then
-  echo $HELMQA_URL | grep -q 127.0.0.1
+if [ -n "$HELMQA_URL" ]; then
   did=
-  if [ $? == 0 ]; then
+  if [[ "$HELMQA_URL" =~ 127.0.0.1 ]]; then
     docker pull jszhaw/helmqa
-    did=`docker run -d -p 127.0.0.1:5000:5000 helmqa`
-    sleep 3
+    did="$(docker run -d -p 127.0.0.1:5000:5000 helmqa)"
   fi
 
-  HELMQA_RESPONSE=$(curl --connect-timeout 5 "$HELMQA_URL=$GIT_REPO")
+  while true; do
+    sleep 1
+    tresponse="$(curl --connect-timeout 5 $HELMQA_URL=$GIT_REPO)" || true
+    if [ -n "$tresponse" ]; then
+      break
+    fi
+    echo "Still spinning up HelmQA container image..."
+  done
 
   if [[ $? != 28 ]]; then
-    TEST_STATUS=$(echo "$HELMQA_RESPONSE" | jq -r .status)
+    tstatus=$(echo "$tresponse" | jq -r .status)
 
-    if [[ "$TEST_STATUS" == "fail" ]]; then
+    if [[ "$tstatus" == "fail" ]]; then
       echo "HelmQA test failed. Check response"
-      echo "$HELMQA_RESPONSE"
+      echo "$tresponse"
       exit 1
-    elif [[ "$TEST_STATUS" == "success" ]]; then
+    elif [[ "$tstatus" == "success" ]]; then
       echo "HelmQA test succeeded. No issues found"
     fi
   else
     echo "HelmQA connection failed. Timed out!"
   fi
 
-  if [ ! -z $did ]; then
-    docker kill $did
+  if [ -n "$did" ]; then
+    docker kill "$did"
   fi
 else
   echo "Skipping HelmQA test."

--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -7,7 +7,7 @@ echo "----> Deploying to $REPO_URL"
 
 GIT_REPO="$(git config remote.origin.url)"
 
-helm_status=$(curl --max-time 10 "$HELMQA_URL=$REPO_URL" | jq -r .status)
+helm_status=$(curl --max-time 10 "$HELMQA_URL=$GIT_REPO" | jq -r .status)
 
 echo "###################################### $helm_status ######################################"
 

--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -7,7 +7,7 @@ echo "----> Deploying to $REPO_URL"
 
 GIT_REPO="$(git config remote.origin.url)"
 
-HELM_RESPONSE=$(curl --max-time 10 "$HELMQA_URL=$GIT_REPO")
+HELM_RESPONSE=$(curl --connect-timeout 5 "$HELMQA_URL=$GIT_REPO")
 
 HELM_STATUS=$(echo "$HELM_RESPONSE" | jq -r .status)
 HELM_RESPONSE_CODE=$(echo "$HELM_RESPONSE" | jq -r .code)

--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-HELMQA_URL=https://helmqa-helmqa.a3c1.starter-us-west-1.openshiftapps.com/livecheck?repo
+HELMQA_URL=https://http://helmqa-zhaw-prod-demos.appuioapp.ch/livecheck?repo
 REPO_URL="${REPO_URL:-https://charts.appuio.ch}"
 echo "----> Deploying to $REPO_URL"
 
@@ -11,12 +11,12 @@ HELMQA_RESPONSE=$(curl --connect-timeout 5 "$HELMQA_URL=$GIT_REPO")
 
 if [[ $? != 28 ]]; then
 	TEST_STATUS=$(echo "$HELMQA_RESPONSE" | jq -r .status)
-	
+
 	if [[ "$TEST_STATUS" == "fail" ]]; then
 		echo "HelmQA test failed. Check response"
 		echo "$HELMQA_RESPONSE"
 		exit 1
-	elif [[ "$TEST_STATUS" == "success" ]]; then 
+	elif [[ "$TEST_STATUS" == "success" ]]; then
 		echo "HelmQA test succeeded. No issues found"
 	fi
 else

--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -1,13 +1,15 @@
 #!/bin/bash
 set -e
 
+HELMQA_URL=https://helmqa-helmqa.a3c1.starter-us-west-1.openshiftapps.com/livecheck?repo
 REPO_URL="${REPO_URL:-https://charts.appuio.ch}"
 echo "----> Deploying to $REPO_URL"
 
 GIT_REPO="$(git config remote.origin.url)"
 
-echo "########################################## $GIT_REPO ######################################"
+helm_status=$(curl --max-time 10 $HELMQA_URL=$REPO_URL | jq -r .status)
 
+echo "###################################### $helm_status ######################################"
 
 tmp="$(mktemp -d)"
 echo "----> Working in $tmp"

--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -8,16 +8,15 @@ echo "----> Deploying to $REPO_URL"
 GIT_REPO="$(git config remote.origin.url)"
 
 HELMQA_RESPONSE=$(curl --connect-timeout 5 "$HELMQA_URL=$GIT_REPO")
-echo "---------------_############################# $?"
+
 if [[ $? != 28 ]]; then
 	TEST_STATUS=$(echo "$HELMQA_RESPONSE" | jq -r .status)
-        echo "-------------------> $TEST_STATUS"
 	
 	if [[ "$TEST_STATUS" == "fail" ]]; then
 		echo "HelmQA test failed. Check response"
-		echo "-------------> $HELMQA_RESPONSE"
+		echo "$HELMQA_RESPONSE"
 		exit 1
-	else 
+	elif [[ "$TEST_STATUS" == "success" ]]; then 
 		echo "HelmQA test succeeded. No issues found"
 	fi
 else

--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -7,9 +7,14 @@ echo "----> Deploying to $REPO_URL"
 
 GIT_REPO="$(git config remote.origin.url)"
 
-helm_status=$(curl --max-time 10 "$HELMQA_URL=$GIT_REPO" | jq -r .status)
+HELM_RESPONSE=$(curl --max-time 10 "$HELMQA_URL=$GIT_REPO")
 
-echo "###################################### $helm_status ######################################"
+HELM_STATUS=$("$HELM_RESPONSE" | jq -r .status)
+HELM_RESPONSE_CODE=$("$HELM_RESPONSE" | jq -r .code)
+
+echo "-------------------> $HELM_STATUS"
+echo "-------------------> $HELM_RESPONSE_CODE"
+
 
 tmp="$(mktemp -d)"
 echo "----> Working in $tmp"

--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -15,6 +15,11 @@ HELM_RESPONSE_CODE=$(echo "$HELM_RESPONSE" | jq -r .code)
 echo "-------------------> $HELM_STATUS"
 echo "-------------------> $HELM_RESPONSE_CODE"
 
+if [[ "$HELM_STATUS" == "fail" ]]; then
+	echo "HelmQA test failed. Check response"
+	echo "-------------> $HELM_RESPONSE"
+	exit 1
+fi
 
 tmp="$(mktemp -d)"
 echo "----> Working in $tmp"

--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -14,13 +14,13 @@ GIT_REPO="$(git config remote.origin.url)"
 if [ -n "$HELMQA_URL" ]; then
   did=
   if [[ "$HELMQA_URL" =~ 127.0.0.1 ]]; then
-    docker pull jszhaw/helmqa
-    did="$(docker run -d -p 127.0.0.1:5000:5000 helmqa)"
+    docker pull docker.io/jszhaw/helmqa
+    did="$(docker run -d -p 127.0.0.1:5000:5000 docker.io/jszhaw/helmqa)"
   fi
 
   while true; do
     sleep 1
-    tresponse="$(curl --connect-timeout 5 $HELMQA_URL=$GIT_REPO)" || true
+    tresponse="$(curl --connect-timeout 5 --max-time 60 $HELMQA_URL=$GIT_REPO)" || true
     if [ -n "$tresponse" ]; then
       break
     fi

--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -9,8 +9,8 @@ GIT_REPO="$(git config remote.origin.url)"
 
 HELM_RESPONSE=$(curl --max-time 10 "$HELMQA_URL=$GIT_REPO")
 
-HELM_STATUS=$("$HELM_RESPONSE" | jq -r .status)
-HELM_RESPONSE_CODE=$("$HELM_RESPONSE" | jq -r .code)
+HELM_STATUS=$(echo "$HELM_RESPONSE" | jq -r .status)
+HELM_RESPONSE_CODE=$(echo "$HELM_RESPONSE" | jq -r .code)
 
 echo "-------------------> $HELM_STATUS"
 echo "-------------------> $HELM_RESPONSE_CODE"

--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -8,7 +8,7 @@ echo "----> Deploying to $REPO_URL"
 GIT_REPO="$(git config remote.origin.url)"
 
 HELMQA_RESPONSE=$(curl --connect-timeout 5 "$HELMQA_URL=$GIT_REPO")
-echo $?
+echo "---------------_############################# $?"
 if [[ $? != 28 ]]; then
 	TEST_STATUS=$(echo "$HELMQA_RESPONSE" | jq -r .status)
         echo "-------------------> $TEST_STATUS"

--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -6,6 +6,9 @@ echo "----> Deploying to $REPO_URL"
 
 GIT_REPO="$(git config remote.origin.url)"
 
+echo "########################################## $GIT_REPO ######################################"
+
+
 tmp="$(mktemp -d)"
 echo "----> Working in $tmp"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,23 @@
----
 language: python
-
 env:
   global:
-    - HELM_URL=https://storage.googleapis.com/kubernetes-helm
-    - HELM_TGZ=helm-v2.9.1-linux-amd64.tar.gz
-    - OUT_DIR=out
-
+  - HELM_URL=https://storage.googleapis.com/kubernetes-helm
+  - HELM_TGZ=helm-v2.9.1-linux-amd64.tar.gz
+  - OUT_DIR=out
+  - secure: WvEYYrEMyCRh4ugVzfxUoeN2aDIdGlhnY2s0O9s+boBwEzCEPDk3Nfn66Y5SnBRJUqOZabp+EskuV+OKrQSijvCPF7xnyN9ZAlwuKVmKAV62cwnSB+NwrKxIACYulj9cKQqTkJGCdMUiXJ5SH9/Ki/v8c4uo8IJrilV4J63gdb+8StBbOYHHkS3aNaERJdNmj5Zg4WeiXV6i1N/cafvtGw0JLZxL7D0If9MOqcqsnqD5MJmj2Ny3VK6fquwBo0Yh+EXAI8+a3/koaZO4Vu4lqv0I6QmZQot3hRvWrr/XSySzBc4maXs0a2Z7FBwLBi5NuWOddt//wn6N/l4xbDl+u/tjqU0mwF8YDAT1e2EgQW+GM6/PfSHsuYOvoQt1dE8CDJhjbSPxvgHpLqN2ydl0mOezv2SIw3BQxegRtL8oAFDGPSm8wSZ/n/r7BzXL+cxEJwch9iL3VUd4O3JQF/a7FA9hjCQDsOgT8EDNUehMh62sWMwJsfaQfUitayv5biw3MXglK5NRgx9oE0t2RlBmTP6TK/CcUkUObwgXBob7K2Jtt1nboFLHTzWm2QgMNYY5rkn1qmtCqMtjL+VwT41A5Zu7QIQ5Pl01eZ5UE5iImVjOPDQ9NEcEt3Na3RFETiR0GXP4vxE5dpwlTvpiUULO3G0h9PahRJzTJv0kDjWjlmk=
 install:
-  - curl -sSLo /tmp/helm.tgz "${HELM_URL}/${HELM_TGZ}"
-  - tar -xzvf /tmp/helm.tgz
-  - PATH=$(pwd)/linux-amd64/:$PATH
-  - helm init --client-only
-
+- curl -sSLo /tmp/helm.tgz "${HELM_URL}/${HELM_TGZ}"
+- tar -xzvf /tmp/helm.tgz
+- PATH=$(pwd)/linux-amd64/:$PATH
+- helm init --client-only
 before_script:
-  - git fetch origin gh-pages
-
-script: ./.ci/build.sh
-
+- git fetch origin gh-pages
+script: "./.ci/build.sh"
 deploy:
   provider: pages
-  local-dir: $OUT_DIR
+  local-dir: "$OUT_DIR"
   skip-cleanup: true
-  github-token: $GITHUB_TOKEN
+  github-token: "$GITHUB_TOKEN"
   keep-history: true
   on:
     branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ install:
 - tar -xzvf /tmp/helm.tgz
 - PATH=$(pwd)/linux-amd64/:$PATH
 - helm init --client-only
+- sudo apt-get install jq
 before_script:
 - git fetch origin gh-pages
 script: "./.ci/build.sh"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,29 @@
+---
 language: python
+
 env:
   global:
-  - HELM_URL=https://storage.googleapis.com/kubernetes-helm
-  - HELM_TGZ=helm-v2.9.1-linux-amd64.tar.gz
-  - OUT_DIR=out
-  - secure: WvEYYrEMyCRh4ugVzfxUoeN2aDIdGlhnY2s0O9s+boBwEzCEPDk3Nfn66Y5SnBRJUqOZabp+EskuV+OKrQSijvCPF7xnyN9ZAlwuKVmKAV62cwnSB+NwrKxIACYulj9cKQqTkJGCdMUiXJ5SH9/Ki/v8c4uo8IJrilV4J63gdb+8StBbOYHHkS3aNaERJdNmj5Zg4WeiXV6i1N/cafvtGw0JLZxL7D0If9MOqcqsnqD5MJmj2Ny3VK6fquwBo0Yh+EXAI8+a3/koaZO4Vu4lqv0I6QmZQot3hRvWrr/XSySzBc4maXs0a2Z7FBwLBi5NuWOddt//wn6N/l4xbDl+u/tjqU0mwF8YDAT1e2EgQW+GM6/PfSHsuYOvoQt1dE8CDJhjbSPxvgHpLqN2ydl0mOezv2SIw3BQxegRtL8oAFDGPSm8wSZ/n/r7BzXL+cxEJwch9iL3VUd4O3JQF/a7FA9hjCQDsOgT8EDNUehMh62sWMwJsfaQfUitayv5biw3MXglK5NRgx9oE0t2RlBmTP6TK/CcUkUObwgXBob7K2Jtt1nboFLHTzWm2QgMNYY5rkn1qmtCqMtjL+VwT41A5Zu7QIQ5Pl01eZ5UE5iImVjOPDQ9NEcEt3Na3RFETiR0GXP4vxE5dpwlTvpiUULO3G0h9PahRJzTJv0kDjWjlmk=
+    - HELM_URL=https://storage.googleapis.com/kubernetes-helm
+    - HELM_TGZ=helm-v2.9.1-linux-amd64.tar.gz
+    - OUT_DIR=out
+
 install:
-- curl -sSLo /tmp/helm.tgz "${HELM_URL}/${HELM_TGZ}"
-- tar -xzvf /tmp/helm.tgz
-- PATH=$(pwd)/linux-amd64/:$PATH
-- helm init --client-only
-- sudo apt-get install jq
+  - curl -sSLo /tmp/helm.tgz "${HELM_URL}/${HELM_TGZ}"
+  - tar -xzvf /tmp/helm.tgz
+  - PATH=$(pwd)/linux-amd64/:$PATH
+  - helm init --client-only
+  - sudo apt-get install jq
+
 before_script:
-- git fetch origin gh-pages
-script: "./.ci/build.sh"
+  - git fetch origin gh-pages
+
+script: ./.ci/build.sh
+
 deploy:
   provider: pages
-  local-dir: "$OUT_DIR"
+  local-dir: $OUT_DIR
   skip-cleanup: true
-  github-token: "$GITHUB_TOKEN"
+  github-token: $GITHUB_TOKEN
   keep-history: true
   on:
     branch: master


### PR DESCRIPTION
The Travis script is enhanced to perform HelmQA checking on the charts. It runs in SaaS mode by default but can also run in Docker mode or be disabled completely. Checks could fail or just warn, right now they always fail.

The code is not yet great, e.g. this could be outsourced into a second script which could ship with HelmQA to be maintained centrally. But it would be good to get some feedback on functionality by chart maintainers to drive the next steps.