### PR TITLE
[Stardog] Remove workaround

### DIFF
--- a/stardog/Chart.yaml
+++ b/stardog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: stardog
-version: 0.0.5
+version: 0.0.6
 appVersion: 6.1.3
 description: Stardog Helm Chart
 home: "https://www.stardog.com/"

--- a/stardog/files/stardog.properties
+++ b/stardog/files/stardog.properties
@@ -1,2 +1,1 @@
 watchdog.enabled=false
-thread.pool.admin.size=10


### PR DESCRIPTION
As confirmed by the Stardog support, this workaround is no longer
needed.