### PR TITLE
[keycloak] Switch to new upstream chart

### DIFF
--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -57,6 +57,9 @@ trap cleanup 0 1 2 3 6 15
 
 # Dependency repos
 helm repo add bitnami https://charts.bitnami.com
+helm repo add codecentric https://codecentric.github.io/helm-charts
+helm repo add jetstack https://charts.jetstack.io
+helm repo add weaveworks https://weaveworks.github.io/flux
 
 charts=$(find ./* -maxdepth 1 -name Chart.yaml -exec dirname "{}" \;)
 changed_files=$(git diff --name-only $TRAVIS_COMMIT_RANGE)

--- a/keycloak/Chart.yaml
+++ b/keycloak/Chart.yaml
@@ -1,5 +1,5 @@
 name: keycloak
-version: 4.8.0
+version: 4.12.0
 appVersion: 5.0.0
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/keycloak/README.md
+++ b/keycloak/README.md
@@ -2,13 +2,12 @@
 
 [Keycloak](http://www.keycloak.org/) is an open source identity and access management for modern applications and services.
 
-The readme for the upstream chart of [Keycloak can be found here](https://github.com/helm/charts/blob/master/stable/keycloak/README.md)  
+The README for the upstream chart of [Keycloak can be found here](https://github.com/codecentric/helm-charts/tree/master/charts/keycloak)
 
-## Adaptations for Openshift
+## Adaptations for OpenShift
 
-After helm updated its dependencies there is a new folder called /charts. In this folder you find the upstream chart from helm/stable.
-There are some minor adaptations necessary to run the [helm/stable Keycloak-Chart] on openshift. To make these adaptations the appuio Keycloak-Chart takes the
-helm/stable Chart just as a dependency. The values.yaml then adds an empty securityContext and a configuration for the route to the chart. The templates-folder contains the openshift-specific definition for the route. Everything else is plain Keycloak.
+There are some minor adaptations necessary to run the Keycloak chart on OpenShift. To make these adaptations the APPUiO Keycloak chart defines the
+codecentric chart as a dependency. The values.yaml then adds an empty securityContext and a configuration for the route to the chart. The templates-folder contains the openshift-specific definition for the route.
 
 ## Configuration
 

--- a/keycloak/requirements.lock
+++ b/keycloak/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: keycloak
-  repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 4.8.0
-digest: sha256:e84398359a6a3276bb62991f5612ea05ae84d59a0a4550221e4c40816698845c
-generated: 2019-03-25T17:12:28.735091152+01:00
+  repository: https://codecentric.github.io/helm-charts
+  version: 4.12.0
+digest: sha256:ebc76d96d16a90db2b995585543ee32a52ce60700cd35451e1193002fda336cf
+generated: 2019-05-14T15:37:11.871431091+02:00

--- a/keycloak/requirements.yaml
+++ b/keycloak/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
   - name: keycloak
-    version: 4.8.0
-    repository: https://kubernetes-charts.storage.googleapis.com/
+    version: 4.12.0
+    repository: https://codecentric.github.io/helm-charts


### PR DESCRIPTION
The one in the stable repo was deprecated in favor of the new one in the
Codecentric repo.