### PR TITLE
[signalilo] Use environment variables for configuration

### DIFF
--- a/signalilo/Chart.yaml
+++ b/signalilo/Chart.yaml
@@ -7,8 +7,8 @@ keywords:
   - alertmanager
   - webhook
   - icinga2
-version: 0.0.1
-appVersion: 0.0.1
+version: 0.0.2
+appVersion: 0.0.2
 sources:
   - https://git.vshn.net/vshn/signalilo
 maintainers:

--- a/signalilo/README.md
+++ b/signalilo/README.md
@@ -37,12 +37,21 @@ Parameter | Description | Default
 `replicaCount` | Number of replicas to run | `2`
 `image.registry` | Image registry | `registry.vshn.net`
 `image.repository` | Image repository | `vshn/signalilo`
-`image.tag` | Image tag | `0.0.1`
+`image.tag` | Image tag | `0.0.2`
 `image.pullPolicy` | Image pull policy | `IfNotPresent`
 `image.username` | Username to pull the image | `""`
 `image.password` | Password to pull the image | `""`
 `image.existingPullSecret` | Existing image pull secret | `""`
-`config` | Configuration for Signalilo (in YAML format) | `{}`
+`config.uuid` | Signalilo UUID (required) |
+`config.icinga_hostname` | Icinga Servicehost name (required) |
+`config.icinga_url` | Icinga master URL (required) |
+`config.icinga_username` | Icinga API user username (required) |
+`config.icinga_password` | Icinga API user password (required if `config.icinga_password_secret` is unset) |
+`config.icinga_password_secret` | Pre-existing secret for icinga API user password (the secret is expected to have a key `icinga_password`) |
+`config.alertmanager_bearer_token` | Bearer token for incoming webhooks (required if `config.alertmanager_bearer_token_secret is unset`) |
+`config.alertmanager_bearer_token_secret` | Pre-existing secret for bearer token for incoming webhooks (the secret is expected to have a key `alertmanager_bearer_token`) |
+`config.alertmanager_port` | Port for incoming webhooks from Alertmanager | `8888`
+`extraEnvVars` | Extra Signalilo configuration (see values.yaml for optional configuration values, and their defaults) | `[]`
 `securityContext.enabled` | Enable security context for the pod | `false`
 `securityContext.runAsUser` | User to run the pod as | `999`
 `securityContext.fsGroup` | fs group to use for the pod | `999`

--- a/signalilo/templates/deployment.yaml
+++ b/signalilo/templates/deployment.yaml
@@ -18,6 +18,8 @@ spec:
       labels:
         app.kubernetes.io/name: {{ include "signalilo.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+      annotations:
+        checksum/tokens-secret: {{ include (print .Template.BasePath "/secret.yaml") . | sha256sum }}
     spec:
       {{- if .Values.securityContext.enabled }}
       securityContext:
@@ -27,10 +29,34 @@ spec:
       containers:
         - name: {{ .Chart.Name }}
           image: {{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}
+          env:
+          - name: SIGNALILO_UUID
+            value: {{ required ".Values.config.uuid is required" .Values.config.uuid | quote }}
+          - name: SIGNALILO_ICINGA_HOSTNAME
+            value: {{ required ".Values.config.icinga_hostname is required" .Values.config.icinga_hostname | quote }}
+          - name: SIGNALILO_ICINGA_URL
+            value:  {{ required ".Values.config.icinga_url is required" .Values.config.icinga_url | quote }}
+          - name: SIGNALILO_ICINGA_USERNAME
+            value: {{ required ".Values.config.icinga_username is required" .Values.config.icinga_username | quote }}
+          - name: SIGNALILO_ICINGA_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.config.icinga_password_secret | default (printf "%s" (include "signalilo.fullname" .)) | quote }}
+                key: "icinga_password"
+          - name: SIGNALILO_ALERTMANAGER_PORT
+            value: {{ .Values.config.alertmanager_port | quote }}
+          - name: SIGNALILO_ALERTMANAGER_BEARER_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.config.alertmanager_bearer_token_secret | default (printf "%s" (include "signalilo.fullname" .)) | quote }}
+                key: "alertmanager_bearer_token"
+{{- if .Values.extraEnvVars }}
+{{ toYaml .Values.extraEnvVars | indent 10 }}
+{{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: 8888
+              containerPort: {{ .Values.config.alertmanager_port }}
               protocol: TCP
           livenessProbe:
             httpGet:
@@ -40,10 +66,6 @@ spec:
             httpGet:
               path: /healthz
               port: http
-          volumeMounts:
-            - name: config
-              mountPath: /etc/signalilo/
-              readOnly: true
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}
@@ -64,7 +86,3 @@ spec:
     {{- else if .Values.image.password }}
         - name: {{ template "signalilo.fullname" . }}-pullsecret
     {{- end }}
-      volumes:
-        - name: config
-          secret:
-            secretName: {{ template "signalilo.fullname" . }}

--- a/signalilo/templates/secret.yaml
+++ b/signalilo/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if or (not .Values.config.icinga_password_secret) (not .Values.config.alertmanager_bearer_token_secret) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -8,4 +9,10 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 data:
-  config.yaml: {{ .Values.config | toYaml | b64enc }}
+{{- if not .Values.config.icinga_password_secret }}
+  icinga_password: {{ required ".Values.config.icinga_password is required" .Values.config.icinga_password | b64enc | quote }}
+{{- end }}
+{{- if not .Values.config.alertmanager_bearer_token_secret }}
+  alertmanager_bearer_token: {{ required ".Values.config.alertmanager_bearer_token is required" .Values.config.alertmanager_bearer_token | b64enc | quote }}
+{{- end }}
+{{- end -}}

--- a/signalilo/values.yaml
+++ b/signalilo/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 2
 image:
   registry: registry.vshn.net
   repository: vshn/signalilo
-  tag: 0.0.1
+  tag: 0.0.2
   pullPolicy: IfNotPresent
   # username:
   # password:
@@ -16,19 +16,32 @@ image:
 nameOverride: ""
 fullnameOverride: ""
 
-config: {}
+# Required configuration
+config:
   # uuid: 9ec06d59-aa0c-4434-b5e2-1aeaf93cd925
-  # host_name: localhost
-  # icinga_api:
-  #   url: https://localhost:5665
-  #   username: icinga_user
-  #   password: icinga_user_pw
-  # alertmanager:
-  #   bearer_token: aaaaaa
-  # gc_interval: 120s
-  # heartbeat_interval: 60s
-  # keep_for: 168h
-  # log_level: 2
+  # icinga_hostname: localhost
+  # icinga_url: https://localhost:5665
+  # icinga_username: icinga_user
+  # icinga_password: icinga_user_pw
+  # icinga_password_secret:
+  alertmanager_port: 8888
+  # alertmanager_bearer_token: aaaaaa
+  # alertmanager_bearer_token_secret:
+
+# Optional extra configuration
+# extraEnvVars:
+# - name: SIGNALILO_LOG_LEVEL
+#   value: "2"
+# - name: SIGNALILO_ICINGA_INSECURE_TLS
+#   value: "false"
+# - name: SIGNALILO_ICINGA_DEBUG
+#   value: "false"
+# - name: SIGNALILO_ICINGA_GC_INTERVAL
+#   value: "15m"
+# - name: SIGNALILO_ICINGA_HEARTBEAT_INTERVAL
+#   value: "60s"
+# - name: SIGNALILO_ICINGA_KEEP_FOR
+#   value: "168h"
 
 securityContext:
   enabled: false


### PR DESCRIPTION
Signalilo v0.0.2 expects to be configured through environment variables.
This commit refactors the helm chart to provide the required config
through environment variables, from values provided in `.Values.config`
and allows extra configuration values to be provided as environment
variables in `.Values.extraEnvVars`.

Signed-off-by: Simon Gerber <simon.gerber@vshn.ch>

<!--
Thank you for contributing to appuio/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

-->

#### What this PR does / why we need it:

The new version v0.0.2 of Signalilo is configurable via environment variables instead of a config file. This PR refactors the Signalilo chart to provide the configuration via environment variables.

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] [DCO](https://github.com/appuio/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR contains starts with chart name e.g. `[chart]`
