### PR TITLE
[stardog] Increase liveness probe delay

### DIFF
--- a/stardog/Chart.yaml
+++ b/stardog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: stardog
-version: 0.0.13
+version: 0.0.14
 appVersion: 6.2.2
 description: Stardog Helm Chart
 home: "https://www.stardog.com/"

--- a/stardog/templates/statefulset.yaml
+++ b/stardog/templates/statefulset.yaml
@@ -84,7 +84,7 @@ spec:
             httpGet:
               path: /admin/healthcheck
               port: stardog
-            initialDelaySeconds: 180
+            initialDelaySeconds: 1800
           readinessProbe:
             httpGet:
               path: /admin/healthcheck


### PR DESCRIPTION
#### What this PR does / why we need it:
Increase liveness probe delay to allow for longer startup time if DBs need to be synced from other
nodes.

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] [DCO](https://github.com/appuio/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR contains starts with chart name e.g. `[chart]`
