### PR TITLE
[Keycloak] Deprecate chart

### DIFF
--- a/keycloak/Chart.yaml
+++ b/keycloak/Chart.yaml
@@ -1,5 +1,6 @@
 name: keycloak
-version: 4.12.0
+version: 5.0.0
+deprecated: true
 appVersion: 5.0.0
 description: Open Source Identity and Access Management For Modern Applications and Services
 keywords:

--- a/keycloak/README.md
+++ b/keycloak/README.md
@@ -1,21 +1,4 @@
-# Keycloak
+# Keycloak DEPRECATED
 
-[Keycloak](http://www.keycloak.org/) is an open source identity and access management for modern applications and services.
 
-The README for the upstream chart of [Keycloak can be found here](https://github.com/codecentric/helm-charts/tree/master/charts/keycloak)
-
-## Adaptations for OpenShift
-
-There are some minor adaptations necessary to run the Keycloak chart on OpenShift. To make these adaptations the APPUiO Keycloak chart defines the
-codecentric chart as a dependency. The values.yaml then adds an empty securityContext and a configuration for the route to the chart. The templates-folder contains the openshift-specific definition for the route.
-
-## Configuration
-
-To override parameters regarding the keycloak-chart (which is helm/stable) you need to address the chart in your values.yaml like following:
-
-```yaml
-keycloak: #prepend
-  keycloak:
-    <key>:<value>
-    ...
-```
+Use the [upstream chart from Codecentric](https://github.com/codecentric/helm-charts/tree/master/charts/keycloak).


### PR DESCRIPTION
The upstream chart from Codecentric now includes the OpenShift route.
Therefore there's no need to have our own chart anymore.

<!--
Thank you for contributing to appuio/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

-->

#### What this PR does / why we need it:

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] [DCO](https://github.com/appuio/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR contains starts with chart name e.g. `[chart]`
