### PR TITLE
[k8up] Added missing permissions for K8up to run PreBackupPod object

### DIFF
--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -59,7 +59,7 @@ trap cleanup 0 1 2 3 6 15
 helm repo add bitnami https://charts.bitnami.com
 helm repo add codecentric https://codecentric.github.io/helm-charts
 helm repo add jetstack https://charts.jetstack.io
-helm repo add weaveworks https://weaveworks.github.io/flux
+helm repo add flux https://fluxcd.github.io/flux
 
 charts=$(find ./* -maxdepth 1 -name Chart.yaml -exec dirname "{}" \;)
 changed_files=$(git diff --name-only $TRAVIS_COMMIT_RANGE)

--- a/k8up/Chart.yaml
+++ b/k8up/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - backup
   - operator
   - appuio
-version: 0.2.1
+version: 0.2.2
 appVersion: v0.1.4
 sources:
   - https://github.com/vshn/k8up

--- a/k8up/templates/clusterrole.yaml
+++ b/k8up/templates/clusterrole.yaml
@@ -50,6 +50,15 @@ rules:
   - roles
   verbs:
   - '*'
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - deployments/scale
+  verbs:
+  - create
+  - delete
+  - watch
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
#### What this PR does / why we need it:

During the preparation of a K8up workshop it was observed that PreBackupPod objects would not run without this permission. The workaround was to manually run the following command and append the permissions:

`kubectl edit clusterroles k8up`

#### Checklist

- [x] [DCO](https://github.com/appuio/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md (not applicable)
- [x] Title of the PR contains starts with chart name e.g. `[chart]`
