### PR TITLE
[Stardog] Limit Promehteus rules to current namespace

### DIFF
--- a/stardog/Chart.yaml
+++ b/stardog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: stardog
-version: 0.0.20
+version: 0.0.21
 appVersion: 6.2.3
 description: Stardog Helm Chart
 home: "https://www.stardog.com/"

--- a/stardog/templates/monitoring/stardog-java-rules.yaml
+++ b/stardog/templates/monitoring/stardog-java-rules.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.metrics.prometheusOperator }}
+{{- $ns_selector :=  printf "namespace=\"%s\"" .Release.Namespace }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
@@ -15,7 +16,7 @@ spec:
     # Appendix: JMX metrics https://sysdig.com/blog/jmx-monitoring-custom-metrics/
     rules:
     - alert: JavaCollectionUsageThresholdExceeded
-      expr: java_lang_memorypool_collectionusagethresholdexceeded > 0
+      expr: java_lang_memorypool_collectionusagethresholdexceeded{ {{ $ns_selector }} } > 0
       for: 1m
       annotations:
         summary: The Java collection usage threshold has been exceeded
@@ -25,7 +26,7 @@ spec:
         app: stardog
         severity: critical
     - alert: JavaMemoryPoolInvalid
-      expr: java_lang_memorypool_valid != 1
+      expr: java_lang_memorypool_valid{ {{ $ns_selector }} } != 1
       for: 1m
       annotations:
         summary: A Java memory pool has become invalid
@@ -35,7 +36,7 @@ spec:
         app: stardog
         severity: critical
     - alert: JavaGarbageCollectorInvalid
-      expr: java_lang_garbagecollector_valid != 1
+      expr: java_lang_garbagecollector_valid{ {{ $ns_selector }} } != 1
       for: 1m
       annotations:
         summary: A Java garbage collector has become invalid
@@ -45,7 +46,7 @@ spec:
         app: stardog
         severity: critical
     - alert: JavaGarbageCollectionTimeExceeded
-      expr: java_lang_garbagecollector_lastgcinfo_duration > 10000
+      expr: java_lang_garbagecollector_lastgcinfo_duration{ {{ $ns_selector }} } > 10000
       for: 1m
       annotations:
         summary: Java garbage collection time exeeded
@@ -55,7 +56,7 @@ spec:
         app: stardog
         severity: warning
     - alert: JavaFileDescriptorsRunningOut
-      expr: java_lang_operatingsystem_maxfiledescriptorcount - java_lang_operatingsystem_openfiledescriptorcount < 1000
+      expr: java_lang_operatingsystem_maxfiledescriptorcount{ {{ $ns_selector }} } - java_lang_operatingsystem_openfiledescriptorcount{ {{ $ns_selector }} } < 1000
       for: 1m
       annotations:
         summary: Java file descriptors are running out
@@ -65,7 +66,7 @@ spec:
         app: stardog
         severity: warning
     - alert: JavaCPULoad
-      expr: java_lang_operatingsystem_processcpuload / java_lang_operatingsystem_availableprocessors > 1
+      expr: java_lang_operatingsystem_processcpuload{ {{ $ns_selector }} } / java_lang_operatingsystem_availableprocessors{ {{ $ns_selector }} } > 1
       for: 30m
       annotations:
         summary: High CPU load
@@ -78,7 +79,7 @@ spec:
   - name: Memory Usage
     rules:
       - alert: JavaLowHeapMemory
-        expr: java_lang_memory_heapmemoryusage_max - java_lang_memory_heapmemoryusage_used < 128 * 1024 * 1024
+        expr: java_lang_memory_heapmemoryusage_max{ {{ $ns_selector }} } - java_lang_memory_heapmemoryusage_used{ {{ $ns_selector }} } < 128 * 1024 * 1024
         for: 1m
         annotations:
           summary: Java Low Heap Memory

--- a/stardog/templates/monitoring/stardog-rules.yaml
+++ b/stardog/templates/monitoring/stardog-rules.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.metrics.prometheusOperator }}
+{{- $ns_selector :=  printf "namespace=\"%s\"" .Release.Namespace }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
@@ -14,7 +15,7 @@ spec:
   - name: Stardog
     rules:
     - alert: StardogOpenConnections
-      expr: stardog_database_openconnections > 32
+      expr: stardog_database_openconnections{ {{ $ns_selector }} } > 32
       for: 1m
       annotations:
         summary: Too many open connections
@@ -24,7 +25,7 @@ spec:
         app: stardog
         severity: critical
     - alert: StardogLicenseExpire
-      expr: stardog_dbms_license_expiration_value < 42
+      expr: stardog_dbms_license_expiration_value{ {{ $ns_selector }} } < 42
       for: 10m
       annotations:
         summary: Stardog license about to expire
@@ -32,5 +33,5 @@ spec:
       labels:
         env: {{ .Release.Name }}
         app: stardog
-        severity: "{{ "{{ if $value lt 21 }}" }}critical{{ "{{ else }}" }}warning{{ "{{ end }}" }}"
+        severity: "{{ "{{ if lt $value 21.0 }}" }}critical{{ "{{ else }}" }}warning{{ "{{ end }}" }}"
 {{- end }}

--- a/stardog/templates/monitoring/zookeeper-rules.yaml
+++ b/stardog/templates/monitoring/zookeeper-rules.yaml
@@ -1,4 +1,5 @@
 {{- if and .Values.metrics.prometheusOperator .Values.zookeeper.enabled }}
+{{- $ns_selector :=  printf "namespace=\"%s\"" .Release.Namespace }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
@@ -14,17 +15,17 @@ spec:
   - name: zookeeper
     rules:
     - alert: ZooKeeperDown
-      expr: zk_up == 0
+      expr: zk_up{ {{ $ns_selector }} } == 0
       for: 10m
       annotations:
         summary: A ZooKeeper instance is down
-        description: The ZooKeeper instance {{ "{{" }} .Labels.zk_host {{ "}}" }} could not be scraped by the ZooKeeper exporter
+        description: The ZooKeeper instance {{ "{{" }} $labels.zk_host {{ "}}" }} could not be scraped by the ZooKeeper exporter
       labels:
         env: {{ .Release.Name }}
         app: zookeeper
         severity: critical
     - alert: ZooKeeperFsyncThresholdExeeded
-      expr: zk_fsync_threshold_exceed_count > 0
+      expr: zk_fsync_threshold_exceed_count{ {{ $ns_selector }} } > 0
       for: 1m
       annotations:
         summary: The ZooKeeper fsync threshold exeeded
@@ -34,7 +35,7 @@ spec:
         app: zookeeper
         severity: critical
     - alert: JavaFileDescriptorsRunningOut
-      expr: zk_max_file_descriptor_count - zk_open_file_descriptor_count < 1000
+      expr: zk_max_file_descriptor_count{ {{ $ns_selector }} } - zk_open_file_descriptor_count{ {{ $ns_selector }} } < 1000
       for: 1m
       annotations:
         summary: Java file descriptors are running out


### PR DESCRIPTION
<!--
Thank you for contributing to appuio/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

-->

#### What this PR does / why we need it:

Make sure the deployed PrometheusRules are scoped to the release's
namespace.

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] [DCO](https://github.com/appuio/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR contains starts with chart name e.g. `[chart]`
