### PR TITLE
[k8up] Document installation without cluster-admin

### DIFF
--- a/k8up/Chart.yaml
+++ b/k8up/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - backup
   - operator
   - appuio
-version: 0.2.2
+version: 0.2.3
 appVersion: v0.1.4
 sources:
   - https://github.com/vshn/k8up

--- a/k8up/README.md
+++ b/k8up/README.md
@@ -24,7 +24,7 @@ K8up uses Wrestic as a backup runner, to learn more about it, please visit [wres
 To install the chart with the release name `k8up`:
 
 ```console
-$ helm install --name k8up appuio/k8up
+helm install --name k8up appuio/k8up
 ```
 
 ## Uninstalling the Chart
@@ -32,7 +32,25 @@ $ helm install --name k8up appuio/k8up
 To uninstall/delete the `k8up` deployment:
 
 ```console
-$ helm delete k8up
+helm delete k8up
+```
+
+## Installing the Chart (without cluster-admin for tiller)
+
+```console
+helm fetch appuio/k8up --untar
+helm template ./k8up/ -x templates/clusterrole.yaml -x templates/clusterrolebinding.yaml --set rbac.enabled=true | kubectl apply -f -
+rm -rf ./k8up/
+helm install --name k8up appuio/k8up --set rbac.enabled=false
+```
+
+## Uninstalling the Chart (without cluster-admin for tiller)
+
+```console
+helm delete k8up
+helm fetch appuio/k8up --untar
+helm template ./k8up/ -x templates/clusterrole.yaml -x templates/clusterrolebinding.yaml --set rbac.enabled=true | kubectl delete -f -
+rm -rf ./k8up/
 ```
 
 ## Configuration


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR adds documentation how K8up can be installed when tiller has no cluster-admin rights.

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [X] [DCO](https://github.com/appuio/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
- [X] Title of the PR contains starts with chart name e.g. `[chart]`
