### PR TITLE
[haproxy] Add Galera configuration

### DIFF
--- a/haproxy/Chart.yaml
+++ b/haproxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 2.1
 description: A Helm chart for HAProxy which can be customized by a config map.
 name: haproxy
-version: 0.0.1
+version: 1.0.0
 maintainers:
   - name: APPUiO Team
     email: info@appuio.ch

--- a/haproxy/README.md
+++ b/haproxy/README.md
@@ -55,13 +55,17 @@ create your own configmap and values.
 | `affinity` | Pod affinity rules | `{}`
 
 ### ldap-tls
+
+Set `haproxy.config` to `ldap-tls` to use the LDAP TLS configuration (default).
+
 | Parameter              | Description            | Default
 |---                     | ---                    | ---
-| `haproxy.config`       | Suffix of the used config-map | ldap-tls
 | `haproxy.ldapTls.backend` | Service the proxy should connect to | none
 | `haproxy.ldapTls.certificatePath` | Path to the corresponding root-certificate | /etc/ssl/certs/ca-certificates.crt
 
 ### galera
+
+Set `haproxy.config` to `galera` to use the Galera configuration.
 
 | Parameter              | Description            | Default
 |---                     | ---                    | ---

--- a/haproxy/README.md
+++ b/haproxy/README.md
@@ -32,10 +32,11 @@ helm delete haproxy
 
 ## Configuration
 
-The configuration of HAProxy is derived through a configmap which in turn can be configured by adjusting the corresponding values in values.yaml.  
-The present example is a configmap to configure HAProxy as a TLS reverse proxy to communicate with an LDAP backend. For different purposes you can  
+The configuration of HAProxy is derived through a configmap which in turn can be configured by adjusting the corresponding values in values.yaml.
+The present example is a configmap to configure HAProxy as a TLS reverse proxy to communicate with an LDAP backend. For different purposes you can
 create your own configmap and values.  
 
+### General parameters
 | Parameter              | Description            | Default
 |---                     | ---                    | ---
 | `replicaCount`         | Number of replicas for the proxy. | 1
@@ -49,8 +50,27 @@ create your own configmap and values.
 | `ingress.tls.secretName`| Name of the secret containing the TLS certificate and key |
 | `haproxy.frontendPort` | Port for the Proxy to listen on the frontend | 30636
 | `haproxy.config`       | Suffix of the used config-map | ldap-tls
-| `haproxy.ldapTls.backend` | Service the proxy should connect to | none
-| `haproxy.ldapTls.certificatePath` | Path to the corresponding root-certificate | /etc/ssl/certs/ca-certificates.crt   
 | `nodeSelector` | Pod node selector | `{}`
 | `tolerations` | Pod tolerations | `[]`
 | `affinity` | Pod affinity rules | `{}`
+
+### ldap-tls
+| Parameter              | Description            | Default
+|---                     | ---                    | ---
+| `haproxy.config`       | Suffix of the used config-map | ldap-tls
+| `haproxy.ldapTls.backend` | Service the proxy should connect to | none
+| `haproxy.ldapTls.certificatePath` | Path to the corresponding root-certificate | /etc/ssl/certs/ca-certificates.crt
+
+### galera
+
+| Parameter              | Description            | Default
+|---                     | ---                    | ---
+| `haproxy.galera.balance` | What balance mode HAProxy should use | source
+| `haproxy.galera.check.enabled` | If mysql-check should be enabled | true
+| `haproxy.galera.check.user` | The database user to use for mysql-check | haproxy
+| `haproxy.galera.nodes` | List of Galera nodes | []
+| `haproxy.galera.nodes.address` | Address of the Galera node |
+| `haproxy.galera.nodes.port` | Port of the Galera node | 3306
+| `haproxy.galera.nodes.backup` | If this node should be used as a backup node | true
+
+To use `mysql-check`, configure a user `haproxy` in the database (see: http://cbonte.github.io/haproxy-dconv/1.9/configuration.html#4-option%20mysql-check for more information).

--- a/haproxy/templates/configmap-galera.yaml
+++ b/haproxy/templates/configmap-galera.yaml
@@ -1,0 +1,39 @@
+{{- if eq .Values.haproxy.config "galera"}}
+{{- $galera := .Values.haproxy.galera -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "{{ include "haproxy.fullname" . }}-galera"
+  labels:
+    app.kubernetes.io/name: {{ include "haproxy.name" . }}
+    helm.sh/chart: {{ include "haproxy.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+data:
+  haproxy.cfg: |-
+    global
+      log stdout local0
+
+    defaults
+      log global
+
+      option dontlognull
+      timeout connect 5s
+      timeout client 10s
+      timeout server 10s
+
+    frontend galera-in
+      bind *:{{ .Values.haproxy.frontendPort }}
+      mode tcp
+      option clitcpka
+      default_backend galera-nodes
+
+    backend galera-nodes
+      mode tcp
+      option srvtcpka
+      balance {{ $galera.balance }}
+      {{ if $galera.check.enabled }}option mysql-check user {{ $galera.check.user }}{{ end }}
+      {{- range $index, $node := .Values.haproxy.galera.nodes }}
+      server node-{{ $index }} {{ $node.address }} {{ default "3306" $node.port }}{{ if $galera.check.enabled }} check{{ end }}{{ if $node.backup }} backup{{ end }}
+      {{- end }}
+{{- end }}

--- a/haproxy/templates/configmap-ldap-tls.yaml
+++ b/haproxy/templates/configmap-ldap-tls.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.haproxy.config "ldap-tls"}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -31,3 +32,4 @@ data:
 
     backend backend
       server ldap {{ .Values.haproxy.ldapTls.backend }} ssl verify required ca-file {{ .Values.haproxy.ldapTls.certificatePath }}
+{{- end}}}

--- a/haproxy/values.yaml
+++ b/haproxy/values.yaml
@@ -28,9 +28,21 @@ service:
 haproxy:
   config: ldap-tls
   frontendPort: 30636
+
   ldapTls:
     certificatePath: /etc/ssl/certs/ca-certificates.crt
     # backend: ldap-example.org
+
+  galera:
+    balance: source # see http://cbonte.github.io/haproxy-dconv/1.9/configuration.html#4-balance
+    check:
+      enabled: true # see http://cbonte.github.io/haproxy-dconv/1.9/configuration.html#option%20mysql-check
+      user: haproxy
+    nodes: []
+    # - address: galera-node-1
+    #   port: 3306
+    #   backup: false
+
 resources:
   limits:
    cpu: 100m


### PR DESCRIPTION
Adds a configuration to use HAProxy as a proxy for a Galera cluster.

Additonally split up the README to document the specific configurations.

Signed-off-by: Tobias Nehrlich <tobias.nehrlich@vshn.ch>

<!--
Thank you for contributing to appuio/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

-->

#### What this PR does / why we need it:

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] [DCO](https://github.com/appuio/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR contains starts with chart name e.g. `[chart]`
