### PR TITLE
[haproxy] Add a missing colon between address and port

### DIFF
--- a/haproxy/Chart.yaml
+++ b/haproxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 2.1
 description: A Helm chart for HAProxy which can be customized by a config map.
 name: haproxy
-version: 1.0.1
+version: 1.0.2
 maintainers:
   - name: APPUiO Team
     email: info@appuio.ch

--- a/haproxy/templates/configmap-galera.yaml
+++ b/haproxy/templates/configmap-galera.yaml
@@ -34,6 +34,6 @@ data:
       balance {{ $galera.balance }}
       {{ if $galera.check.enabled }}option mysql-check user {{ $galera.check.user }}{{ end }}
       {{- range $index, $node := .Values.haproxy.galera.nodes }}
-      server node-{{ $index }} {{ $node.address }} {{ default "3306" $node.port }}{{ if $galera.check.enabled }} check{{ end }}{{ if $node.backup }} backup{{ end }}
+      server node-{{ $index }} {{ $node.address }}:{{ default "3306" $node.port }}{{ if $galera.check.enabled }} check{{ end }}{{ if $node.backup }} backup{{ end }}
       {{- end }}
 {{- end }}


### PR DESCRIPTION
Signed-off-by: Tobias Nehrlich <tobias.nehrlich@vshn.ch>

<!--
Thank you for contributing to appuio/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

-->

#### What this PR does / why we need it:
Fixes the Galera configuration by adding a colon.

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] [DCO](https://github.com/appuio/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR contains starts with chart name e.g. `[chart]`
