### PR TITLE
[Stardog] Update readiness probe

### DIFF
--- a/stardog/Chart.yaml
+++ b/stardog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: stardog
-version: 0.0.21
+version: 0.0.22
 appVersion: 6.2.3
 description: Stardog Helm Chart
 home: "https://www.stardog.com/"

--- a/stardog/templates/statefulset.yaml
+++ b/stardog/templates/statefulset.yaml
@@ -94,7 +94,7 @@ spec:
             initialDelaySeconds: 1800
           readinessProbe:
             httpGet:
-              path: /admin/alive
+              path: /admin/healthcheck
               port: stardog
             initialDelaySeconds: 15
           resources:


### PR DESCRIPTION
#### What this PR does / why we need it:

Use the `/admin/healthcheck` endpoint for readiness probes as it
reflects the readiness of a Stardog instance. It will succeed only if
the instance joined the cluster.

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] [DCO](https://github.com/appuio/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR contains starts with chart name e.g. `[chart]`
