### PR TITLE
[Stardog] Mount emptyDir for tmp data

### DIFF
--- a/stardog/Chart.yaml
+++ b/stardog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: stardog
-version: 0.0.22
+version: 0.0.23
 appVersion: 6.2.3
 description: Stardog Helm Chart
 home: "https://www.stardog.com/"

--- a/stardog/templates/statefulset.yaml
+++ b/stardog/templates/statefulset.yaml
@@ -87,6 +87,8 @@ spec:
             - name: config
               mountPath: /var/opt/stardog/log4j2.xml
               subPath: log4j2.xml
+            - name: tmp
+              mountPath: /tmp/
           livenessProbe:
             httpGet:
               path: /admin/alive
@@ -132,7 +134,7 @@ spec:
               memory: 128Mi
               cpu: 500m
       {{- end }}
-      terminationGracePeriodSeconds: 60
+      terminationGracePeriodSeconds: 600
       securityContext: {{ .Values.stardog.securityContext | toYaml | nindent 8 }}
       imagePullSecrets:
       {{- if .Values.image.existingPullSecret }}
@@ -147,6 +149,8 @@ spec:
         - name: config
           configMap:
             name: {{ template "stardog.fullname" . }}-config
+        - name: tmp
+          emptyDir: {}
         {{- if .Values.metrics.enabled }}
         - name: jmx-config
           configMap:


### PR DESCRIPTION

<!--
Thank you for contributing to appuio/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

-->

#### What this PR does / why we need it:

Have the temp data in an emptyDir, instead of in the pod fs.

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] [DCO](https://github.com/appuio/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR contains starts with chart name e.g. `[chart]`
