### PR TITLE
[openshift-route] Update named service port

### DIFF
--- a/openshift-route/Chart.yaml
+++ b/openshift-route/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "v1"
 description: A Helm chart for OpenShift that simply creates a Route object
 name: openshift-route
-version: 1.0.0
+version: 1.0.1

--- a/openshift-route/README.md
+++ b/openshift-route/README.md
@@ -21,7 +21,7 @@ The following table lists the configurable parameters of the chart. For defaults
 | `path` | Subpath of the route. | `""`
 | `annotations` | Annotations on the route object. | `{}`
 | `service.name` | The backend service name of the route. Required. | `""`
-| `service.targetPort` | The port of the backend service. | `8080`
+| `service.targetPort` | The port of the backend service. The port is aware of the named ports of the service, so it can be a name too. | `http`
 | `service.weight` | Weight of the service endpoint. | `100`
 | `wildcardPolicy` | Wildcard Policy of the route. | `None`
 | `tls.enabled` | Whether to secure the Route with TLS. | `false`

--- a/openshift-route/values.yaml
+++ b/openshift-route/values.yaml
@@ -26,7 +26,7 @@ tls:
 
 service:
   name: ""
-  targetPort: 8080
+  targetPort: http
   weight: 100
 
 alternateBackends: []


### PR DESCRIPTION
Signed-off-by: Chris <github.account@chrigel.net>

<!--
Thank you for contributing to appuio/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

-->

#### What this PR does / why we need it:

Updates the default route to `http`, as that would take the port number of the associated service object.

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] [DCO](https://github.com/appuio/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR contains starts with chart name e.g. `[chart]`
