### PR TITLE
[k8up] upgrade to latest version

### DIFF
--- a/k8up/Chart.yaml
+++ b/k8up/Chart.yaml
@@ -6,8 +6,8 @@ keywords:
   - backup
   - operator
   - appuio
-version: 0.2.3
-appVersion: v0.1.4
+version: 0.2.4
+appVersion: v0.1.6
 sources:
   - https://github.com/vshn/k8up
 maintainers:

--- a/k8up/values.yaml
+++ b/k8up/values.yaml
@@ -1,6 +1,6 @@
 ---
 k8up_operator:
-  image: docker.io/vshn/k8up:v0.1.4
+  image: docker.io/vshn/k8up:v0.1.6
   ## Allows the specification of additional environment variables
   envVars:
     - name: BACKUP_IMAGE


### PR DESCRIPTION
I am assuming the v0.1.6 release from November is stable now.

#### What this PR does / why we need it:
To have the latest version in production.

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] [DCO](https://github.com/appuio/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR contains starts with chart name e.g. `[chart]`
