### PR TITLE
Add livenessProbe to Stardog

### DIFF
--- a/stardog/templates/statefulset.yaml
+++ b/stardog/templates/statefulset.yaml
@@ -94,6 +94,13 @@ spec:
               path: /admin/healthcheck
               port: stardog
             initialDelaySeconds: 15
+          livenessProbe:
+            httpGet:
+              path: /admin/alive
+              port: stardog
+            initialDelaySeconds: 15
+            periodSeconds: 60
+            failureThreshold: 5
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- if .Values.metrics.enabled }}


### PR DESCRIPTION
To avoid the situation having a zombie pod we are adding the livenessProbe.

Resolves: [SBAR-173](https://ticket.vshn.net/browse/SBAR-173)