### PR TITLE
Ignore test dirs in packaged helm releases

### DIFF
--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -71,7 +71,7 @@ for chart in $charts; do
   chart=${chart:2}
   chart_changed=false
   for file in $changed_files; do
-    if [[ $file == "$chart/"* ]]; then
+    if [[ $file != "$chart/test/"* && $file == "$chart/"* ]]; then
       chart_changed=true
       break
     fi

--- a/snappass/.helmignore
+++ b/snappass/.helmignore
@@ -20,5 +20,5 @@
 .idea/
 *.tmproj
 .vscode/
-
+test/
 README.md

--- a/snappass/Chart.yaml
+++ b/snappass/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "v1.4.2"
 description: A Helm chart for SnapPass
 name: snappass
-version: 0.2.5
+version: 0.2.6

--- a/stardog/.helmignore
+++ b/stardog/.helmignore
@@ -19,3 +19,4 @@
 .project
 .idea/
 *.tmproj
+test/

--- a/stardog/Chart.yaml
+++ b/stardog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: stardog
-version: 0.2.3
+version: 0.2.4
 appVersion: 6.2.3
 description: Stardog Helm Chart
 home: "https://www.stardog.com/"

--- a/trifid/.helmignore
+++ b/trifid/.helmignore
@@ -20,3 +20,4 @@
 .idea/
 *.tmproj
 .vscode/
+test/

--- a/trifid/Chart.yaml
+++ b/trifid/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 name: trifid
 description: Trifid Helm chart
 type: application
-version: 1.1.1
+version: 1.1.2
 appVersion: "2.3.3"
 home: "https://github.com/zazuko/trifid"


### PR DESCRIPTION
<!--
Thank you for contributing to appuio/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

-->

#### What this PR does / why we need it:

We often get PRs from Renovate for Go modules which fail in pipeline since the chart version was not bumped. I do not see a reason why the chart should be shipped with the Go testing files, by ignoring the test in the CI build, the build won't fail in the future, so we can safely merge PRs from Renovate without a Chart version bump.

See e.g. #130 

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] [DCO](https://github.com/appuio/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR contains starts with chart name e.g. `[chart]`
