### PR TITLE
[Stardog] Add alert for not ready pods

### DIFF
--- a/stardog/Chart.yaml
+++ b/stardog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: stardog
-version: 0.2.4
+version: 0.2.5
 appVersion: 6.2.3
 description: Stardog Helm Chart
 home: "https://www.stardog.com/"

--- a/stardog/templates/monitoring/stardog-rules.yaml
+++ b/stardog/templates/monitoring/stardog-rules.yaml
@@ -34,4 +34,14 @@ spec:
         env: {{ .Release.Name }}
         app: stardog
         severity: "{{ "{{ if lt $value 21.0 }}" }}critical{{ "{{ else }}" }}warning{{ "{{ end }}" }}"
+    - alert: StardogPodsNotReady
+      expr: kube_statefulset_status_replicas_ready{ {{ $ns_selector }}, statefulset="{{ include "stardog.fullname" . }}" } != {{ .Values.replicaCount }}
+      for: 10m
+      annotations:
+        summary: Pods of Stardog StatefulSet not ready
+        description: Only {{ "{{" }} $value {{ "}}" }} of {{ .Values.replicaCount }} Stardog pods are ready in namespace {{ "{{" }} $labels.namespace {{ "}}" }}.
+      labels:
+        env: {{ .Release.Name }}
+        app: stardog
+        severity: "{{ "{{ if lt $value 2.0 }}" }}critical{{ "{{ else }}" }}warning{{ "{{ end }}" }}"
 {{- end }}

--- a/stardog/templates/monitoring/zookeeper-rules.yaml
+++ b/stardog/templates/monitoring/zookeeper-rules.yaml
@@ -44,4 +44,14 @@ spec:
         env: {{ .Release.Name }}
         app: zookeeper
         severity: warning
+    - alert: ZooKeeperPodsNotReady
+      expr: kube_statefulset_status_replicas_ready{ {{ $ns_selector }}, statefulset="{{ include "stardog.zookeeper.fullname" . }}" } != {{ .Values.zookeeper.replicaCount }}
+      for: 10m
+      annotations:
+        summary: Pods of ZooKeeper StatefulSet not ready
+        description: Only {{ "{{" }} $value {{ "}}" }} of {{ .Values.zookeeper.replicaCount }} ZooKeeper pods are ready in namespace {{ "{{" }} $labels.namespace {{ "}}" }}.
+      labels:
+        env: {{ .Release.Name }}
+        app: zookeeper
+        severity: "{{ "{{ if lt $value 2.0 }}" }}critical{{ "{{ else }}" }}warning{{ "{{ end }}" }}"
 {{- end }}


### PR DESCRIPTION
<!--
Thank you for contributing to appuio/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

-->

#### What this PR does / why we need it:
If not all pods of a StatefulSet are ready, fire an alert. As long as at
least 2 pods are ready it's a warning, otherwise a critical alert.

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] [DCO](https://github.com/appuio/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR contains starts with chart name e.g. `[chart]`
