### PR TITLE
[openshift-route] Apply helm3 workaround for broken OpenShift API spec

### DIFF
--- a/openshift-route/Chart.yaml
+++ b/openshift-route/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "v1"
 description: A Helm chart for OpenShift that simply creates a Route object
 name: openshift-route
-version: 1.1.1
+version: 1.1.2

--- a/openshift-route/templates/_helpers.tpl
+++ b/openshift-route/templates/_helpers.tpl
@@ -43,3 +43,14 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
+
+{{/*
+See related Helm3 issues:
+- https://github.com/openshift/origin/issues/24060
+- https://github.com/helm/helm/issues/6830
+*/}}
+{{- define "chart.helmRouteFix" -}}
+status:
+  ingress:
+    - host: ""
+{{- end -}}

--- a/openshift-route/templates/route.yaml
+++ b/openshift-route/templates/route.yaml
@@ -49,3 +49,4 @@ spec:
   alternateBackends:
     {{- toYaml . | nindent 4 }}
 {{- end }}
+{{ include "chart.helmRouteFix" . }}


### PR DESCRIPTION

#### What this PR does / why we need it:

In a wild goose chase, trying to migrate some helm v2 releases to v3 I stumbled across this error:
```
Comparing release=test-helm3-route, chart=../../appuio/charts/openshift-route
********************

	Release was not present in Helm.  Diff will show entire contents as new.

********************

in ./route-test.yaml: failed processing release test-helm3-route: helm3 exited with status 1:
  Error: Failed to render chart: exit status 1: Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: ValidationError(Route): missing required field "status" in com.github.openshift.api.route.v1.Route
  
  Error: plugin "diff" exited with error
```

This is not an error from diff (so `apply` doesn't work either). Googling around I found these: 
- https://github.com/helm/helm/issues/6830
- https://github.com/openshift/origin/issues/24060
- https://bugzilla.redhat.com/show_bug.cgi?id=1773682

This PR is now applying the same workaround as described in: https://github.com/openshift/origin/issues/24060#issuecomment-574422393 (tested & verified to)

However, it looks like a lot more Objects are affected (ImageStreams, BuildConfigs, etc) I don't know much we can workaround in those cases. Need to be aware of that for future Helm migrations.

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] [DCO](https://github.com/appuio/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR contains starts with chart name e.g. `[chart]`
