### PR TITLE
[k8up] Lower resource defaults

### DIFF
--- a/k8up/Chart.yaml
+++ b/k8up/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - backup
   - operator
   - appuio
-version: 0.5.0
+version: 0.5.1
 appVersion: v0.1.9
 sources:
   - https://github.com/vshn/k8up

--- a/k8up/values.yaml
+++ b/k8up/values.yaml
@@ -67,8 +67,7 @@ rbac:
 
 resources:
   limits:
-    cpu: 1
-    memory: 2Gi
+    memory: 256Mi
   requests:
-    cpu: 0.5
-    memory: 0.5Gi
+    cpu: 20m
+    memory: 128Mi


### PR DESCRIPTION
<!--
Thank you for contributing to appuio/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

-->

#### What this PR does / why we need it:

- Even on pretty busy clusters, 2 Gi Memory limit is way too high, causing deployment errors on quota-enabled namespaces. Current memory usage is approx. 10mb per 100 namespaces.
- [Upstream K8s best practices](https://learnk8s.io/production-best-practices) recommend to not specify CPU limits for production usage

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] [DCO](https://github.com/appuio/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR contains starts with chart name e.g. `[chart]`
