### PR TITLE
[k8up] Add dedicated timezone helm variable

### DIFF
--- a/k8up/Chart.yaml
+++ b/k8up/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - backup
   - operator
   - appuio
-version: 0.5.1
+version: 0.6.0
 appVersion: v0.1.9
 sources:
   - https://github.com/vshn/k8up

--- a/k8up/README.md
+++ b/k8up/README.md
@@ -63,6 +63,7 @@ The following table lists the configurable parameters of the k8up chart. For the
 | `k8up.backupImage.repository` | The backup runner image repository                      | `docker.io/vshn/wrestic`
 | `k8up.backupImage.tag`        | The backup runner image tag                             | see `values.yaml` for latest supported version
 | `k8up.envVars`                | Allows the specification of additional environment variables for the k8up operator | `[]`
+| `k8up.timezone`               | Specifies the timezone K8up is using for scheduling. Empty value defaults to the timezone in which Kubernetes is deployed. Accepts `tz database` compatible entries, e.g. `Europe/Zurich` | `""`
 | `rbac.create`                 | Create cluster roles and rolebinding                    | `true`
 | `metrics.service.type` | Service type of the metrics endpoint | `ClusterIP`
 | `metrics.service.port` | Service port of the metrics endpoint | `8080`

--- a/k8up/templates/deployment.yaml
+++ b/k8up/templates/deployment.yaml
@@ -32,6 +32,10 @@ spec:
             - name: BACKUP_IMAGE
               value: "{{ .repository}}:{{ .tag }}"
           {{- end }}
+          {{- with .Values.k8up.timezone }}
+            - name: TZ
+              value: {{ . }}
+          {{- end }}
           {{- if .Values.k8up.envVars }}
             {{- toYaml .Values.k8up.envVars | nindent 12 }}
           {{- end }}

--- a/k8up/test/deployment_test.go
+++ b/k8up/test/deployment_test.go
@@ -17,11 +17,13 @@ func Test_Deployment_ShouldRender_EnvironmentVariables(t *testing.T) {
 	wantRepo := "repository"
 	wantTag := "tag"
 	wantVar := "BACKUP_IMAGE"
+	wantTimezone := "Europe/Zurich"
 	options := &helm.Options{
 		ValuesFiles: []string{"testdata/deployment_1.yaml"},
 		SetValues: map[string]string{
 			"k8up.backupImage.repository": wantRepo,
 			"k8up.backupImage.tag":        wantTag,
+			"k8up.timezone":               wantTimezone,
 		},
 	}
 
@@ -30,8 +32,10 @@ func Test_Deployment_ShouldRender_EnvironmentVariables(t *testing.T) {
 	envs := got.Spec.Template.Spec.Containers[0].Env
 	assert.Equalf(t, wantVar, envs[0].Name, "Deployment does not use required Env %s", wantVar)
 	assert.Equalf(t, wantRepo+":"+wantTag, envs[0].Value, "Deployment does not use required Env Value from %s", wantVar)
-	assert.Equal(t, "VARIABLE", envs[1].Name, "Deployment does not use configured Env Name")
-	assert.Equal(t, "VALUE", envs[1].Value, "Deployment does not use configured Env Value")
+	assert.Equal(t, "TZ", envs[1].Name)
+	assert.Equal(t, wantTimezone, envs[1].Value)
+	assert.Equal(t, "VARIABLE", envs[2].Name, "Deployment does not use configured Env Name")
+	assert.Equal(t, "VALUE", envs[2].Value, "Deployment does not use configured Env Value")
 }
 
 func Test_Deployment_ShouldRender_Affinity(t *testing.T) {
@@ -69,7 +73,7 @@ func Test_Deployment_ShouldRender_CustomServiceAccount(t *testing.T) {
 	assert.Equal(t, want, serviceName, "Deployment does not render configured serviceName")
 }
 
-func Test_Deployment_ShouldRender_DefaultResources(t *testing.T) {
+func Test_Deployment_ShouldRender_Resources(t *testing.T) {
 	want := "1Gi"
 	options := &helm.Options{
 		SetValues: map[string]string{

--- a/k8up/test/service_test.go
+++ b/k8up/test/service_test.go
@@ -32,7 +32,7 @@ func Test_Service_GivenTypeNodePort_WhenNodePortDefine_ThenRenderNodePort(t *tes
 	options := &helm.Options{
 		SetValues: map[string]string{
 			"metrics.service.nodePort": fmt.Sprintf("%d", expectedPort),
-			"metrics.service.type": "NodePort",
+			"metrics.service.type":     "NodePort",
 		},
 	}
 

--- a/k8up/values.yaml
+++ b/k8up/values.yaml
@@ -24,6 +24,7 @@ k8up:
   backupImage:
     repository: docker.io/vshn/wrestic
     tag: v0.1.8
+  timezone: ""
 
 podSecurityContext: {}
 securityContext: {}


### PR DESCRIPTION
<!--
Thank you for contributing to appuio/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

-->

#### What this PR does / why we need it:

It's a currently undocumented feature to modify the timezone, but already used productively

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] [DCO](https://github.com/appuio/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR contains starts with chart name e.g. `[chart]`
