### PR TITLE
[data-cube-curation] use chart appversion as image tag & update the app

### DIFF
--- a/data-cube-curation/Chart.yaml
+++ b/data-cube-curation/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 name: data-cube-curation
 description: RDF Data Cube curation service
 
-version: 0.1.1
-appVersion: 0.2.0
+version: 0.1.2
+appVersion: 0.3.0
 home: https://github.com/zazuko/data-cube-curation

--- a/data-cube-curation/templates/deployment.yaml
+++ b/data-cube-curation/templates/deployment.yaml
@@ -28,7 +28,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ tpl .Values.image.tag . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http

--- a/data-cube-curation/values.yaml
+++ b/data-cube-curation/values.yaml
@@ -34,7 +34,7 @@ replicaCount: 1
 
 image:
   repository: docker.io/zazuko/datacube
-  tag: api_0.2.0
+  tag: "{{ .Chart.AppVersion }}"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
#### What this PR does / why we need it:

This updates the data-cube-curation app to a newer version. It also changes the `image.tag` value to use the `Chart.AppVersion` by default.

#### Checklist

- [x] [DCO](https://github.com/appuio/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
- [x] Title of the PR contains starts with chart name e.g. `[chart]`
