### PR TITLE
[data-cube-curation] bump image 0.3.0 -> 0.3.1

### DIFF
--- a/data-cube-curation/Chart.yaml
+++ b/data-cube-curation/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 name: data-cube-curation
 description: RDF Data Cube curation service
 
-version: 0.1.2
-appVersion: 0.3.0
+version: 0.1.3
+appVersion: 0.3.1
 home: https://github.com/zazuko/data-cube-curation


### PR DESCRIPTION
#### What this PR does / why we need it:

Updates the data-cube-curation app to the latest version.

App changelogs are here:
 - https://github.com/zazuko/data-cube-curation/blob/master/api/CHANGELOG.md#031-2020-06-22
 - https://github.com/zazuko/data-cube-curation/blob/master/ui/CHANGELOG.md#040-2020-05-06


#### Checklist

- [x] [DCO](https://github.com/appuio/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR contains starts with chart name e.g. `[chart]`
