### PR TITLE
[Stardog] Only run postinstall if replicas > 0

### DIFF
--- a/stardog/Chart.yaml
+++ b/stardog/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v1
 name: stardog
-version: 0.2.7
+version: 0.2.8
 appVersion: 6.2.3
 description: Stardog Helm Chart
 home: "https://www.stardog.com/"

--- a/stardog/requirements.lock
+++ b/stardog/requirements.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: zookeeper
   repository: https://charts.bitnami.com/bitnami
   version: 5.14.4
-digest: sha256:852f6d662dde6c1df67ba50a2c5c5545e57567ea09246d053131b3c93e2f8f00
-generated: "2020-05-25T09:19:16.569458+02:00"
+digest: sha256:13a0276f894f6e6d74de482084ac1bb11df201a626ec389c26ee59c8de4ab6bf
+generated: "2020-07-02T16:52:33.785873337+02:00"

--- a/stardog/templates/post-install-job.yaml
+++ b/stardog/templates/post-install-job.yaml
@@ -1,4 +1,4 @@
-{{- if or .Release.IsInstall .Values.stardog.users }}
+{{- if and (or .Release.IsInstall .Values.stardog.users) .Values.replicaCount }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/stardog/test/go.sum
+++ b/stardog/test/go.sum
@@ -200,6 +200,7 @@ github.com/gruntwork-io/terratest v0.26.1/go.mod h1:ONEOU6Fv3a1rN16Z5t5yWbV57DkV
 github.com/gruntwork-io/terratest v0.26.2/go.mod h1:ONEOU6Fv3a1rN16Z5t5yWbV57DkVC7665yRyvu3aWnk=
 github.com/gruntwork-io/terratest v0.26.5/go.mod h1:ONEOU6Fv3a1rN16Z5t5yWbV57DkVC7665yRyvu3aWnk=
 github.com/gruntwork-io/terratest v0.27.1/go.mod h1:ONEOU6Fv3a1rN16Z5t5yWbV57DkVC7665yRyvu3aWnk=
+github.com/gruntwork-io/terratest v0.27.2 h1:T3TXpOWSHP/3hR4EWHuv/byWkkHuHGjA1ycVrdf3ThQ=
 github.com/gruntwork-io/terratest v0.27.2/go.mod h1:ONEOU6Fv3a1rN16Z5t5yWbV57DkVC7665yRyvu3aWnk=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
@@ -337,6 +338,7 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
@@ -543,6 +545,7 @@ gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
@@ -553,10 +556,12 @@ honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt
 k8s.io/api v0.17.0/go.mod h1:npsyOePkeP0CPwyGfXDHxvypiYMJxBWAMpQxCaJ4ZxI=
 k8s.io/api v0.17.3 h1:XAm3PZp3wnEdzekNkcmj/9Y1zdmQYJ1I4GKSBBZ8aG0=
 k8s.io/api v0.17.3/go.mod h1:YZ0OTkuw7ipbe305fMpIdf3GLXZKRigjtZaV5gzC2J0=
+k8s.io/api v0.17.4 h1:HbwOhDapkguO8lTAE8OX3hdF2qp8GtpC9CW/MQATXXo=
 k8s.io/api v0.17.4/go.mod h1:5qxx6vjmwUVG2nHQTKGlLts8Tbok8PzHl4vHtVFuZCA=
 k8s.io/apimachinery v0.17.0/go.mod h1:b9qmWdKlLuU9EBh+06BtLcSf/Mu89rWL33naRxs1uZg=
 k8s.io/apimachinery v0.17.3 h1:f+uZV6rm4/tHE7xXgLyToprg6xWairaClGVkm2t8omg=
 k8s.io/apimachinery v0.17.3/go.mod h1:gxLnyZcGNdZTCLnq3fgzyg2A5BVCHTNDFrw8AmuJ+0g=
+k8s.io/apimachinery v0.17.4 h1:UzM+38cPUJnzqSQ+E1PY4YxMHIzQyCg29LOoGfo79Zw=
 k8s.io/apimachinery v0.17.4/go.mod h1:gxLnyZcGNdZTCLnq3fgzyg2A5BVCHTNDFrw8AmuJ+0g=
 k8s.io/apiserver v0.17.0/go.mod h1:ABM+9x/prjINN6iiffRVNCBR2Wk7uY4z+EtEGZD48cg=
 k8s.io/client-go v0.17.0 h1:8QOGvUGdqDMFrm9sD6IUFl256BcffynGoe80sxgTEDg=

--- a/stardog/test/postinstall_test.go
+++ b/stardog/test/postinstall_test.go
@@ -1,0 +1,42 @@
+package test
+
+import (
+	"testing"
+
+	batchv1 "k8s.io/api/batch/v1"
+
+	"github.com/gruntwork-io/terratest/modules/helm"
+	"github.com/stretchr/testify/assert"
+)
+
+var tplPostInstallJob = []string{"templates/post-install-job.yaml"}
+
+func Test_PostInstallJob_GivenReplicaCount_WhenZero_ThenDoNotRenderJob(t *testing.T) {
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"stardog.adminPassword":     adminPassword,
+			"replicaCount":	"0",
+		},
+	}
+
+	output, err := helm.RenderTemplateE(t, options, helmChartPath, releaseName, tplPostInstallJob)
+
+	assert.Error(t, err)
+	assert.Equal(t, "Error: could not find template templates/post-install-job.yaml in chart", output)
+}
+
+func Test_PostInstallJob_GivenReplicaCount_WhenGreaterThanZero_ThenRenderJob(t *testing.T) {
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"stardog.adminPassword":     adminPassword,
+			"replicaCount":	"1",
+		},
+	}
+
+	output := helm.RenderTemplate(t, options, helmChartPath, releaseName, tplPostInstallJob)
+
+	job := batchv1.Job{}
+	helm.UnmarshalK8SYaml(t, output, &job)
+
+	assert.NotEmpty(t, job.Spec)
+}


### PR DESCRIPTION
Signed-off-by: Carole Hamer <carole.hamer@vshn.ch>

<!--
Thank you for contributing to appuio/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

-->

#### What this PR does / why we need it:

This prevents the postinstall job from running when the chart is installed with replicaCount equal to zero. The postinstall job requires at least one running pod in order to terminate successfully, so setting the replica count to zero via gitops always leads to a fail state without this change.

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] [DCO](https://github.com/appuio/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR contains starts with chart name e.g. `[chart]`
