### PR TITLE
WIP: [Stardog] Expose stardog prometheus endpoint in Stardog 7.3.2 ServiceMonitor

### DIFF
--- a/stardog/Chart.yaml
+++ b/stardog/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: stardog
-version: 0.3.0
-appVersion: 7.2.0
+version: 0.5.0
+appVersion: 7.3.2
 description: Stardog Helm Chart
 home: "https://www.stardog.com/"
 icon: https://d33wubrfki0l68.cloudfront.net/img/c920235ff153186ab17617ce2bce193d867fa80c/stardog-logo.png

--- a/stardog/files/stardog-wrapper.sh
+++ b/stardog/files/stardog-wrapper.sh
@@ -151,7 +151,7 @@ if $ensure_role_grants; then
     grant_object=${grant_arr[2]}
     log "Granting '${action_name}' permission to role '${role_name}' for '${grant_object}'"
     grant_command="${admin_bin} role grant --passwd ${admin_pw} --action ${action_name} --object ${grant_object} ${role_name}"
-    grep -E "(already has)|(Successfully)" - < <(${grant_command}) || ${grant_command}
+    grep -E "(exists)|(Successfully)" - < <(${grant_command}) || ${grant_command}
 fi
 
 if $assign_role; then

--- a/stardog/templates/monitoring/stardog-servicemonitor.yaml
+++ b/stardog/templates/monitoring/stardog-servicemonitor.yaml
@@ -13,11 +13,33 @@ spec:
     matchLabels:
       app.kubernetes.io/name: {{ include "stardog.name" . }}
   endpoints:
-  - port: metrics
+  - basicAuth:
+      password:
+        name: {{ include "stardog.fullname" . }}-user-passwords
+        key: admin
+      username:
+        # unless there is a cleaner way of doing this, the name "admin" must be stored in a secret:
+        name: {{ template "stardog.fullname" . }}-admin-username
+        key: adminusername
+    interval: 3s
+    path: /admin/status/prometheus
+    port: stardog
     interval: 3s
     scrapeTimeout: 3s
   jobLabel: app.kubernetes.io/instance
   podTargetLabels:
     - app.kubernetes.io/component
     - app.kubernetes.io/name
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "stardog.fullname" . }}-admin-username
+  labels:
+    app.kubernetes.io/name: {{ include "stardog.name" . }}
+    helm.sh/chart: {{ include "stardog.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+stringData:
+  adminusername: admin
 {{- end }}

--- a/stardog/values.yaml
+++ b/stardog/values.yaml
@@ -11,7 +11,7 @@ image:
   registry: stardog-eps-docker.jfrog.io
   # username:
   # password:
-  tag: 7.2.0
+  tag: 7.3.2
   pullPolicy: IfNotPresent
   # existingPullSecret: my-image-pull-secret
 
@@ -81,7 +81,7 @@ persistence:
   # storageClass: -
 
 metrics:
-  enabled: true
+  enabled: false
   prometheusOperator: false
   image:
     registry: docker.io


### PR DESCRIPTION
Signed-off-by: Carole Hamer <carole.hamer@vshn.ch>

<!--
Thank you for contributing to appuio/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

-->

#### What this PR does / why we need it:

Replace the use of the jmx-metrics sidecar with the Stardog 7.3 Prometheus endpoint.

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] [DCO](https://github.com/appuio/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR contains starts with chart name e.g. `[chart]`
