### PR TITLE
[data-cube-curation] fix graph store variable name

### DIFF
--- a/data-cube-curation/Chart.yaml
+++ b/data-cube-curation/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 name: data-cube-curation
 description: RDF Data Cube curation service
 
-version: 0.1.3
+version: 0.1.4
 appVersion: 0.3.1
 home: https://github.com/zazuko/data-cube-curation

--- a/data-cube-curation/templates/deployment.yaml
+++ b/data-cube-curation/templates/deployment.yaml
@@ -106,7 +106,7 @@ spec:
                 name: {{ $sparqlSecretName }}
                 key: graphStoreEndpoint
                 optional: false
-          - name: GRAPH_STORE_USERNAME
+          - name: GRAPH_STORE_USER
             valueFrom:
               secretKeyRef:
                 name: {{ $sparqlSecretName }}


### PR DESCRIPTION
#### What this PR does / why we need it:

This fixes the graph store username environment variable in the data-cube-curation chart. Those variables can be seen here: https://github.com/zazuko/data-cube-curation/blob/cffd73e899d0ac9038963d0e8cf709b0f5352b35/api/lib/services/gitLab/trigger.ts#L31-L33

#### Checklist

- [x] [DCO](https://github.com/appuio/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR contains starts with chart name e.g. `[chart]`
