### PR TITLE
[data-cube-curation] bump to 0.4.0 & OIDC authentication support

### DIFF
--- a/data-cube-curation/Chart.yaml
+++ b/data-cube-curation/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 name: data-cube-curation
 description: RDF Data Cube curation service
 
-version: 0.1.4
-appVersion: 0.3.1
+version: 0.2.0
+appVersion: 0.4.0
 home: https://github.com/zazuko/data-cube-curation

--- a/data-cube-curation/templates/configmap.yaml
+++ b/data-cube-curation/templates/configmap.yaml
@@ -10,6 +10,9 @@ data:
   s3Bucket: {{ required "A valid dataCubeCuration.s3.bucket entry is required!" .Values.dataCubeCuration.s3.bucket | quote }}
   gitlabPipeline: {{ required "A valid dataCubeCuration.gitlab.pipeline entry is required!" .Values.dataCubeCuration.gitlab.pipeline | quote }}
   gitlabPipelineBranch: {{ required "A valid dataCubeCuration.gitlab.branch entry is required!" .Values.dataCubeCuration.gitlab.branch | quote }}
+  authIssuer: {{ required "A valid dataCubeCuration.auth.issuer entry is required!" .Values.dataCubeCuration.auth.issuer | quote }}
+  authClientId: {{ required "A valid dataCubeCuration.auth.clientId entry is required!" .Values.dataCubeCuration.auth.clientId | quote }}
+  authAudience: {{ required "A valid dataCubeCuration.auth.audience entry is required!" .Values.dataCubeCuration.auth.audience | quote }}
 {{- if .Values.dataCubeCuration.debug }}
   debug: {{ .Values.dataCubeCuration.debug | quote }}
 {{- end -}}

--- a/data-cube-curation/templates/deployment.yaml
+++ b/data-cube-curation/templates/deployment.yaml
@@ -155,6 +155,22 @@ spec:
                 name: {{ $fullName }}
                 key: gitlabPipelineBranch
 
+          - name: AUTH_ISSUER
+            valueFrom:
+              configMapKeyRef:
+                name: {{ $fullName }}
+                key: authIssuer
+          - name: AUTH_CLIENT_ID
+            valueFrom:
+              configMapKeyRef:
+                name: {{ $fullName }}
+                key: authClientId
+          - name: AUTH_AUDIENCE
+            valueFrom:
+              configMapKeyRef:
+                name: {{ $fullName }}
+                key: authAudience
+
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/data-cube-curation/values.yaml
+++ b/data-cube-curation/values.yaml
@@ -28,7 +28,10 @@ dataCubeCuration:
     pipeline: ""
     branch: ""
     token: ""
-
+  auth:
+    issuer: ""
+    clientId: ""
+    audience: ""
 
 replicaCount: 1
 


### PR DESCRIPTION
#### What this PR does / why we need it:

This updates the data-cube-curation app to the latest version. It includes (mandatory) OIDC authentication support, so this PR adds the values needed.

#### Checklist

- [x] [DCO](https://github.com/appuio/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR contains starts with chart name e.g. `[chart]`
