### PR TITLE
[data-cube-curation] support setting the access request URL

### DIFF
--- a/data-cube-curation/Chart.yaml
+++ b/data-cube-curation/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 name: data-cube-curation
 description: RDF Data Cube curation service
 
-version: 0.2.0
-appVersion: 0.4.0
+version: 0.3.0
+appVersion: 0.6.1
 home: https://github.com/zazuko/data-cube-curation

--- a/data-cube-curation/templates/configmap.yaml
+++ b/data-cube-curation/templates/configmap.yaml
@@ -13,6 +13,9 @@ data:
   authIssuer: {{ required "A valid dataCubeCuration.auth.issuer entry is required!" .Values.dataCubeCuration.auth.issuer | quote }}
   authClientId: {{ required "A valid dataCubeCuration.auth.clientId entry is required!" .Values.dataCubeCuration.auth.clientId | quote }}
   authAudience: {{ required "A valid dataCubeCuration.auth.audience entry is required!" .Values.dataCubeCuration.auth.audience | quote }}
+{{- if .Values.dataCubeCuration.auth.accessRequest }}
+  authAccessRequest: {{ .Values.dataCubeCuration.auth.accessRequest | quote }}
+{{- end }}
 {{- if .Values.dataCubeCuration.debug }}
   debug: {{ .Values.dataCubeCuration.debug | quote }}
 {{- end -}}

--- a/data-cube-curation/templates/deployment.yaml
+++ b/data-cube-curation/templates/deployment.yaml
@@ -170,6 +170,12 @@ spec:
               configMapKeyRef:
                 name: {{ $fullName }}
                 key: authAudience
+          - name: AUTH_ACCESS_REQUEST
+            valueFrom:
+              configMapKeyRef:
+                name: {{ $fullName }}
+                key: authAccessRequest
+                optional: true
 
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/data-cube-curation/values.yaml
+++ b/data-cube-curation/values.yaml
@@ -32,6 +32,7 @@ dataCubeCuration:
     issuer: ""
     clientId: ""
     audience: ""
+    # accessRequest: ""
 
 replicaCount: 1
 


### PR DESCRIPTION
#### What this PR does / why we need it:

It adds the `dataCubeCuration.auth.accessRequest` value that sets the `AUTH_ACCESS_REQUEST` environment variable. This variable is used to redirect the user to a page where the user can request access to the app.

It also bumps the app version to 0.6.1

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] [DCO](https://github.com/appuio/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR contains starts with chart name e.g. `[chart]`
