### PR TITLE
[haproxy] Allow DNS service discovery

### DIFF
--- a/haproxy/Chart.yaml
+++ b/haproxy/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: 2.1
+appVersion: "2.2"
 description: A Helm chart for HAProxy which can be customized by a config map.
 name: haproxy
-version: 1.1.0
+version: 1.1.1
 maintainers:
   - name: APPUiO Team
     email: info@appuio.ch

--- a/haproxy/README.md
+++ b/haproxy/README.md
@@ -79,3 +79,21 @@ Set `haproxy.config` to `galera` to use the Galera configuration.
 | `haproxy.galera.nodes.backup` | If this node should be used as a backup node | true
 
 To use `mysql-check`, configure a user `haproxy` in the database (see: http://cbonte.github.io/haproxy-dconv/1.9/configuration.html#4-option%20mysql-check for more information).
+
+### galerak8s
+
+Set `haproxy.config` to `galerak8s` to use the Galera configuration with DNS service discovery. See https://www.haproxy.com/de/blog/dns-service-discovery-haproxy/
+
+| Parameter              | Description            | Default
+|---                     | ---                    | ---
+| `haproxy.galerak8s.balance` | What balance mode HAProxy should use | source
+| `haproxy.galerak8s.check.enabled` | If check should be enabled | true
+| `haproxy.galerak8s.check.mysql.enabled` | If mysql-check should be enabled (requires check.enabled) | true
+| `haproxy.galerak8s.check.mysql.user` | The database user to use for mysql-check | haproxy
+| `haproxy.galerak8s.nameserver` | The DNS server to use for service lookup | 10.43.0.10:53
+| `haproxy.galerak8s.dnsservicename` | The DNS Record for service discovery | mycluster-mariadb-galera-headless
+| `haproxy.galerak8s.nodeCount` | Max number of nodes in the backend | 3
+| `haproxy.galerak8s.port` | Port of the Galera node | 3306
+
+
+

--- a/haproxy/README.md
+++ b/haproxy/README.md
@@ -90,10 +90,8 @@ Set `haproxy.config` to `galerak8s` to use the Galera configuration with DNS ser
 | `haproxy.galerak8s.check.enabled` | If check should be enabled | true
 | `haproxy.galerak8s.check.mysql.enabled` | If mysql-check should be enabled (requires check.enabled) | true
 | `haproxy.galerak8s.check.mysql.user` | The database user to use for mysql-check | haproxy
-| `haproxy.galerak8s.nameserver` | The DNS server to use for service lookup | 10.43.0.10:53
 | `haproxy.galerak8s.dnsservicename` | The DNS Record for service discovery | mycluster-mariadb-galera-headless
 | `haproxy.galerak8s.nodeCount` | Max number of nodes in the backend | 3
 | `haproxy.galerak8s.port` | Port of the Galera node | 3306
-
 
 

--- a/haproxy/templates/configmap-galerak8s.yaml
+++ b/haproxy/templates/configmap-galerak8s.yaml
@@ -17,7 +17,7 @@ data:
 
     
     resolvers mydns
-      nameserver dns1 {{ $galera.nameserver }}
+      parse-resolv-conf
       accepted_payload_size 8192 # allow larger DNS payloads
 
     defaults

--- a/haproxy/templates/configmap-galerak8s.yaml
+++ b/haproxy/templates/configmap-galerak8s.yaml
@@ -1,0 +1,45 @@
+{{- if eq .Values.haproxy.config "galerak8s"}}
+{{- $galera := .Values.haproxy.galerak8s -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "{{ include "haproxy.fullname" . }}-galerak8s"
+  labels:
+    app.kubernetes.io/name: {{ include "haproxy.name" . }}
+    helm.sh/chart: {{ include "haproxy.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+data:
+  haproxy.cfg: |-
+    global
+      log stdout local0
+      stats socket :9000 mode 660 level admin
+
+    
+    resolvers mydns
+      nameserver dns1 {{ $galera.nameserver }}
+      accepted_payload_size 8192 # allow larger DNS payloads
+
+    defaults
+      log global
+
+      option dontlognull
+      timeout connect 5s
+      timeout client 10s
+      timeout server 10s
+
+    frontend galera-in
+      bind *:{{ .Values.haproxy.frontendPort }}
+      mode tcp
+      option clitcpka
+      default_backend galera-nodes
+
+    backend galera-nodes
+      mode tcp
+      option srvtcpka
+      balance {{ $galera.balance }}
+
+      {{ if and $galera.check.enabled $galera.check.mysql.enabled }}option mysql-check user {{ $galera.check.mysql.user }}{{ end }}
+      server-template node- {{ $galera.nodeCount}} {{ $galera.dnsservicename}}:{{ default "3306" $galera.port }} check resolvers mydns init-addr none
+
+{{- end }}

--- a/haproxy/templates/configmap-galerak8s.yaml
+++ b/haproxy/templates/configmap-galerak8s.yaml
@@ -40,6 +40,6 @@ data:
       balance {{ $galera.balance }}
 
       {{ if and $galera.check.enabled $galera.check.mysql.enabled }}option mysql-check user {{ $galera.check.mysql.user }}{{ end }}
-      server-template node- {{ $galera.nodeCount}} {{ $galera.dnsservicename}}:{{ default "3306" $galera.port }} check resolvers mydns init-addr none
+      server-template node- {{ $galera.nodeCount}} {{ $galera.dnsservicename}}:{{ default "3306" $galera.port }} {{ if $galera.check.enabled }} check{{ end }} resolvers mydns init-addr none
 
 {{- end }}

--- a/haproxy/values.yaml
+++ b/haproxy/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: docker.io/haproxytech/haproxy-debian
-  tag: 2.1
+  tag: 2.2
   pullPolicy: IfNotPresent
 
 ingress:
@@ -44,6 +44,18 @@ haproxy:
     # - address: galera-node-1
     #   port: 3306
     #   backup: false
+
+  galerak8s:
+    nameserver: 10.43.0.10:53 # This should be your kubedns service
+    balance: source # see http://cbonte.github.io/haproxy-dconv/1.9/configuration.html#4-balance
+    check:
+      enabled: true
+      mysql:
+        enabled: true # see http://cbonte.github.io/haproxy-dconv/1.9/configuration.html#option%20mysql-check
+        user: haproxy
+    dnsservicename: mycluster-mariadb-galera-headless
+    port: 3306
+    nodeCount: 3
 
 resources:
   limits:

--- a/haproxy/values.yaml
+++ b/haproxy/values.yaml
@@ -46,7 +46,6 @@ haproxy:
     #   backup: false
 
   galerak8s:
-    nameserver: 10.43.0.10:53 # This should be your kubedns service
     balance: source # see http://cbonte.github.io/haproxy-dconv/1.9/configuration.html#4-balance
     check:
       enabled: true


### PR DESCRIPTION
#### What this PR does / why we need it:

Allow usage of DNS service discorvery in HAProxy: https://www.haproxy.com/de/blog/dns-service-discovery-haproxy/
This adds a new config `galerak8s` which can be used e.g. with Kubernetes headless services.

#### Checklist
- [x] [DCO](https://github.com/appuio/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR contains starts with chart name e.g. `[chart]`
