### PR TITLE
[HAProxy] Allow metric relabelings

### DIFF
--- a/haproxy/Chart.yaml
+++ b/haproxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 2.3.2
 description: A Helm chart for HAProxy which can be customized by a config map.
 name: haproxy
-version: 1.2.7
+version: 1.3.0
 maintainers:
   - name: APPUiO Team
     email: info@appuio.ch

--- a/haproxy/README.md
+++ b/haproxy/README.md
@@ -76,6 +76,8 @@ create your own configmap and values.
 | `metrics.serviceMonitor.namespace` | Optional namespace which Prometheus is running in |
 | `metrics.serviceMonitor.interval` | How frequently to scrape metrics (use by default, falling back to Prometheus' default) |
 | `metrics.serviceMonitor.selector` | Default to kube-prometheus install (CoreOS recommended), but should be set according to Prometheus install | `{ prometheus: kube-prometheus }`
+| `metrics.serviceMonitor.relabelings` | ServiceMonitor relabelings. Value is evaluated as a template | `[]`
+| `metrics.serviceMonitor.metricRelabelings` | ServiceMonitor metricRelabelings. Value is evaluated as a template | `[]`
 | `metrics.service.type` | Kubernetes Service type (haproxy metrics) | `ClusterIP`
 | `metrics.service.annotations` | Annotations for the metrics service | `{}`
 | `metrics.service.labels` | Additional labels for the metrics service | `{}`

--- a/haproxy/templates/_tplvalues.tpl
+++ b/haproxy/templates/_tplvalues.tpl
@@ -1,0 +1,13 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Renders a value that contains template.
+Usage:
+{{ include "common.tplvalues.render" ( dict "value" .Values.path.to.the.Value "context" $) }}
+*/}}
+{{- define "common.tplvalues.render" -}}
+    {{- if typeIs "string" .value }}
+        {{- tpl .value .context }}
+    {{- else }}
+        {{- tpl (.value | toYaml) .context }}
+    {{- end }}
+{{- end -}}

--- a/haproxy/templates/servicemonitor.yaml
+++ b/haproxy/templates/servicemonitor.yaml
@@ -23,6 +23,12 @@ spec:
     {{- if .Values.metrics.serviceMonitor.interval }}
     interval: {{ .Values.metrics.serviceMonitor.interval }}
     {{- end }}
+    {{- if .Values.metrics.serviceMonitor.relabelings }}
+    relabelings: {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.serviceMonitor.relabelings "context" $) | nindent 6 }}
+    {{- end }}
+    {{- if .Values.metrics.serviceMonitor.metricRelabelings }}
+    metricRelabelings: {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.serviceMonitor.metricRelabelings "context" $) | nindent 6 }}
+    {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ template "haproxy.name" . }}

--- a/haproxy/values.yaml
+++ b/haproxy/values.yaml
@@ -108,6 +108,24 @@ metrics:
     selector:
       prometheus: kube-prometheus
 
+    ## RelabelConfigs to apply to samples before scraping
+    ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#relabelconfig
+    ## Value is evalued as a template
+    ##
+    relabelings: []
+
+    ## MetricRelabelConfigs to apply to samples before ingestion
+    ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#relabelconfig
+    ## Value is evalued as a template
+    ##
+    metricRelabelings: []
+    #  - sourceLabels:
+    #      - "__name__"
+    #    targetLabel: "__name__"
+    #    action: replace
+    #    regex: '(.*)'
+    #    replacement: 'example_prefix_$1'
+
   prometheusRule:
     enabled: false
     additionalLabels: {}


### PR DESCRIPTION
Configure metric relabelings on the ServiceMonitor.

As implemented for the Redis chart: https://github.com/bitnami/charts/pull/4942

<!--
Thank you for contributing to appuio/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

-->

#### What this PR does / why we need it:

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] [DCO](https://github.com/appuio/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR contains starts with chart name e.g. `[chart]`
