### PR TITLE
[HAProxy] Use health check endpoint

### DIFF
--- a/haproxy/Chart.yaml
+++ b/haproxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 2.3.4
 description: A Helm chart for HAProxy which can be customized by a config map.
 name: haproxy
-version: 1.3.3
+version: 1.3.4
 maintainers:
   - name: APPUiO Team
     email: info@appuio.ch

--- a/haproxy/templates/_helpers.tpl
+++ b/haproxy/templates/_helpers.tpl
@@ -30,3 +30,22 @@ Create chart name and version as used by the chart label.
 {{- define "haproxy.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+HAProxy config for stats and metrics
+*/}}
+{{- define "haproxy.metricsConfig" -}}
+{{- if .Values.metrics.enabled }}
+frontend stats
+  mode http
+  bind *:9000
+  stats enable
+  stats uri /stats
+  stats refresh 3s
+  monitor-uri /healthz
+  option http-use-htx
+  option dontlog-normal
+  option httplog
+  http-request use-service prometheus-exporter if { path /metrics }
+{{- end }}
+{{- end -}}

--- a/haproxy/templates/configmap-galera.yaml
+++ b/haproxy/templates/configmap-galera.yaml
@@ -26,20 +26,7 @@ data:
       timeout client {{ $galera.timeout.client }}
       timeout server {{ $galera.timeout.client }}
 
-    {{- if .Values.metrics.enabled }}
-    frontend stats
-      mode http
-      bind *:9000
-
-      stats enable
-      stats uri /stats
-      stats refresh 3s
-
-      option http-use-htx
-      option dontlog-normal
-      option httplog
-      http-request use-service prometheus-exporter if { path /metrics }
-    {{- end }}
+    {{- include "haproxy.metricsConfig" . | nindent 4 }}
 
     frontend galera-in
       bind *:{{ .Values.haproxy.frontendPort }}

--- a/haproxy/templates/configmap-galerak8s.yaml
+++ b/haproxy/templates/configmap-galerak8s.yaml
@@ -26,20 +26,7 @@ data:
       timeout client {{ $galera.timeout.client }}
       timeout server {{ $galera.timeout.client }}
 
-    {{- if .Values.metrics.enabled }}
-    frontend stats
-      mode http
-      bind *:9000
-
-      stats enable
-      stats uri /stats
-      stats refresh 3s
-
-      option http-use-htx
-      option dontlog-normal
-      option httplog
-      http-request use-service prometheus-exporter if { path /metrics }
-    {{- end }}
+    {{- include "haproxy.metricsConfig" . | nindent 4 }}
 
     frontend galera-in
       bind *:{{ .Values.haproxy.frontendPort }}

--- a/haproxy/templates/configmap-ldap-tls.yaml
+++ b/haproxy/templates/configmap-ldap-tls.yaml
@@ -25,20 +25,7 @@ data:
       timeout  check 15s
       timeout  check 15s
 
-    {{- if .Values.metrics.enabled }}
-    frontend stats
-      mode http
-      bind *:9000
-
-      stats enable
-      stats uri /stats
-      stats refresh 3s
-
-      option http-use-htx
-      option dontlog-normal
-      option httplog
-      http-request use-service prometheus-exporter if { path /metrics }
-    {{- end }}
+    {{- include "haproxy.metricsConfig" . | nindent 4 }}
 
     frontend frontend
       bind *:{{ .Values.haproxy.frontendPort }}

--- a/haproxy/templates/configmap-redisk8s.yaml
+++ b/haproxy/templates/configmap-redisk8s.yaml
@@ -26,20 +26,7 @@ data:
       timeout client {{ $redisk8s.timeout.client }}
       timeout server {{ $redisk8s.timeout.client }}
 
-    {{- if .Values.metrics.enabled }}
-    frontend stats
-      mode http
-      bind *:9000
-
-      stats enable
-      stats uri /stats
-      stats refresh 3s
-
-      option http-use-htx
-      option dontlog-normal
-      option httplog
-      http-request use-service prometheus-exporter if { path /metrics }
-    {{- end }}
+    {{- include "haproxy.metricsConfig" . | nindent 4 }}
 
     frontend redis
       bind *:{{ .Values.haproxy.frontendPort }}

--- a/haproxy/templates/deployment.yaml
+++ b/haproxy/templates/deployment.yaml
@@ -41,14 +41,25 @@ spec:
               containerPort: 9000
             {{- end }}
           readinessProbe:
+          {{- if .Values.metrics.enabled }}
+            httpGet:
+              path: /healthz
+              port: metrics
+          {{- else }}
             tcpSocket:
               port: frontend
-            initialDelaySeconds: 5
-            periodSeconds: 10
+          {{- end }}
+            initialDelaySeconds: 3
           livenessProbe:
+          {{- if .Values.metrics.enabled }}
+            httpGet:
+              path: /healthz
+              port: metrics
+          {{- else }}
             tcpSocket:
               port: frontend
-            initialDelaySeconds: 15
+          {{- end }}
+            initialDelaySeconds: 120
             periodSeconds: 20
           resources:
             {{- toYaml .Values.resources | nindent 12 }}


### PR DESCRIPTION
Make use of the health check endpoint [1] if metrics are enabled. Also
factor out the stats frontend.

[1] https://www.haproxy.com/documentation/hapee/latest/onepage/#4-monitor-uri

Signed-off-by: Simon Rüegg <simon@rueggs.ch>

<!--
Thank you for contributing to appuio/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

-->

#### What this PR does / why we need it:

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] [DCO](https://github.com/appuio/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR contains starts with chart name e.g. `[chart]`
