### PR TITLE
Update metrics-server image, version and Helm chart apiVersion

### DIFF
--- a/metrics-server/Chart.yaml
+++ b/metrics-server/Chart.yaml
@@ -1,8 +1,9 @@
-apiVersion: v1
-appVersion: 0.3.6
+apiVersion: v2
+appVersion: 0.3.7
 description: Metrics Server is a cluster-wide aggregator of resource usage data.
+type: application
 name: metrics-server
-version: 2.11.4
+version: 2.12.0
 keywords:
 - metrics-server
 home: https://github.com/kubernetes-incubator/metrics-server

--- a/metrics-server/README.md
+++ b/metrics-server/README.md
@@ -12,8 +12,8 @@ Parameter | Description | Default
 `serviceAccount.name` | Service account to be used. If not set and `serviceAccount.create` is `true`, a name is generated using the fullname template | ``
 `apiService.create` | Create the v1beta1.metrics.k8s.io API service | `true`
 `hostNetwork.enabled` | Enable hostNetwork mode | `false`
-`image.repository` | Image repository | `k8s.gcr.io/metrics-server-amd64`
-`image.tag` | Image tag | `v0.3.2`
+`image.repository` | Image repository | `k8s.gcr.io/metrics-server/metrics-server`
+`image.tag` | Image tag | `v0.3.7`
 `image.pullPolicy` | Image pull policy | `IfNotPresent`
 `imagePullSecrets` | Image pull secrets | `[]`
 `args` | Command line arguments | `[]`

--- a/metrics-server/values.yaml
+++ b/metrics-server/values.yaml
@@ -27,8 +27,8 @@ hostNetwork:
   enabled: false
 
 image:
-  repository: k8s.gcr.io/metrics-server-amd64
-  tag: v0.3.6
+  repository: k8s.gcr.io/metrics-server/metrics-server
+  tag: v0.3.7
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []


### PR DESCRIPTION
* Change image location from k8s.gcr.io/metrics-server-amd64 to
  k8s.gcr.io/metrics-server/metrics-server
* Increase the version from v0.3.6 to v0.3.7
* Update the Helm chart apiVersion from v1 to v2

