### PR TITLE
[k8up] Bump K8up to v1.0.2

### DIFF
--- a/k8up/Chart.yaml
+++ b/k8up/Chart.yaml
@@ -6,8 +6,8 @@ keywords:
   - backup
   - operator
   - restic
-version: 1.0.1
-appVersion: v1.0.1
+version: 1.0.2
+appVersion: v1.0.2
 sources:
   - https://github.com/vshn/k8up
   - https://github.com/vshn/wrestic

--- a/k8up/README.md
+++ b/k8up/README.md
@@ -1,6 +1,6 @@
 # K8up - Kubernetes and OpenShift Backup Operator based on restic
 
-![Version: 1.0.1](https://img.shields.io/badge/Version-1.0.1-informational?style=flat-square) ![AppVersion: v1.0.1](https://img.shields.io/badge/AppVersion-v1.0.1-informational?style=flat-square)
+![Version: 1.0.1](https://img.shields.io/badge/Version-1.0.1-informational?style=flat-square) ![AppVersion: v1.0.2](https://img.shields.io/badge/AppVersion-v1.0.2-informational?style=flat-square)
 
 <!---
 This README.md file is automatically generated with helm-docs!
@@ -14,9 +14,9 @@ Edit the README.gotmpl.md template instead.
 
 ```bash
 # Install CRDs for K8s >= 1.16:
-kubectl apply -f https://github.com/vshn/k8up/releases/download/v1.0.1/k8up-crd.yaml
+kubectl apply -f https://github.com/vshn/k8up/releases/download/v1.0.2/k8up-crd.yaml
 # Install CRDs for K8s <= 1.15 (e.g. OpenShift 3.11):
-kubectl apply -f https://github.com/vshn/k8up/releases/download/v1.0.1/k8up-crd-legacy.yaml
+kubectl apply -f https://github.com/vshn/k8up/releases/download/v1.0.2/k8up-crd-legacy.yaml
 
 helm repo add appuio https://charts.appuio.ch
 helm install k8up appuio/k8up
@@ -45,7 +45,7 @@ Document your changes in values.yaml and let `make helm-docs` generate this sect
 | image.pullPolicy | string | `"IfNotPresent"` | Operator image pull policy |
 | image.registry | string | `"quay.io"` | Operator image registry |
 | image.repository | string | `"vshn/k8up"` | Operator image repository |
-| image.tag | string | `"v1.0.1"` | Operator image tag (version) |
+| image.tag | string | `"v1.0.2"` | Operator image tag (version) |
 | imagePullSecrets | list | `[]` |  |
 | k8up.backupImage.repository | string | `"quay.io/vshn/wrestic"` | The backup runner image repository |
 | k8up.backupImage.tag | string | `"v0.1.9"` | The backup runner image tag |

--- a/k8up/rbac-kustomize/kustomization.yaml
+++ b/k8up/rbac-kustomize/kustomization.yaml
@@ -1,5 +1,5 @@
 resources:
-  - github.com/vshn/k8up/config/rbac?ref=v1.0.1
+  - github.com/vshn/k8up/config/rbac?ref=v1.0.2
 
 namePrefix: PREFIX-
 namespace: "{{ .Release.Namespace }}"

--- a/k8up/templates/rbac.yaml
+++ b/k8up/templates/rbac.yaml
@@ -107,6 +107,7 @@ rules:
 - apiGroups:
   - backup.appuio.ch
   resources:
+  - archives/finalizers
   - archives/status
   verbs:
   - get
@@ -127,6 +128,7 @@ rules:
 - apiGroups:
   - backup.appuio.ch
   resources:
+  - backups/finalizers
   - backups/status
   verbs:
   - get
@@ -147,6 +149,7 @@ rules:
 - apiGroups:
   - backup.appuio.ch
   resources:
+  - checks/finalizers
   - checks/status
   verbs:
   - get
@@ -185,6 +188,7 @@ rules:
 - apiGroups:
   - backup.appuio.ch
   resources:
+  - prebackuppods/finalizers
   - prebackuppods/status
   verbs:
   - get
@@ -205,6 +209,7 @@ rules:
 - apiGroups:
   - backup.appuio.ch
   resources:
+  - prunes/finalizers
   - prunes/status
   verbs:
   - get
@@ -225,6 +230,7 @@ rules:
 - apiGroups:
   - backup.appuio.ch
   resources:
+  - restores/finalizers
   - restores/status
   verbs:
   - get
@@ -245,6 +251,7 @@ rules:
 - apiGroups:
   - backup.appuio.ch
   resources:
+  - schedules/finalizers
   - schedules/status
   verbs:
   - get
@@ -265,6 +272,7 @@ rules:
 - apiGroups:
   - batch
   resources:
+  - jobs/finalizers
   - jobs/status
   verbs:
   - get

--- a/k8up/values.yaml
+++ b/k8up/values.yaml
@@ -10,7 +10,7 @@ image:
   # -- Operator image repository
   repository: vshn/k8up
   # -- Operator image tag (version)
-  tag: v1.0.1
+  tag: v1.0.2
 
 imagePullSecrets: []
 serviceAccount:


### PR DESCRIPTION
#### What this PR does / why we need it:

* Bump [K8up to v1.0.2](https://github.com/vshn/k8up/releases/tag/v1.0.2)
* Updates RBAC rules

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] [DCO](https://github.com/appuio/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR contains starts with chart name e.g. `[chart]`
