### PR TITLE
[k8up] Update wrestic to 0.2.3

### DIFF
--- a/k8up/Chart.yaml
+++ b/k8up/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - backup
   - operator
   - restic
-version: 1.0.3
+version: 1.0.4
 appVersion: v1.0.3
 sources:
   - https://github.com/vshn/k8up

--- a/k8up/README.md
+++ b/k8up/README.md
@@ -48,7 +48,7 @@ Document your changes in values.yaml and let `make helm-docs` generate this sect
 | image.tag | string | `"v1.0.3"` | Operator image tag (version) |
 | imagePullSecrets | list | `[]` |  |
 | k8up.backupImage.repository | string | `"quay.io/vshn/wrestic"` | The backup runner image repository |
-| k8up.backupImage.tag | string | `"v0.2.2"` | The backup runner image tag |
+| k8up.backupImage.tag | string | `"v0.2.3"` | The backup runner image tag |
 | k8up.enableLeaderElection | bool | `true` | Specifies whether leader election should be enabled. Disable this for K8s versions < 1.16 |
 | k8up.envVars | list | `[]` | envVars allows the specification of additional environment variables. See [values.yaml](values.yaml) how to specify See documentation which variables are supported. |
 | k8up.globalResources | object | empty values, [see supported units][supported-units] | Specify the resource requests and limits that the Pods should have when they are scheduled by K8up. You are still able to override those via K8up resources, but this gives cluster administrators custom defaults. |

--- a/k8up/values.yaml
+++ b/k8up/values.yaml
@@ -35,7 +35,7 @@ k8up:
     # -- The backup runner image repository
     repository: quay.io/vshn/wrestic
     # -- The backup runner image tag
-    tag: v0.2.2
+    tag: v0.2.3
 
   # -- Specifies the timezone K8up is using for scheduling.
   # Empty value defaults to the timezone in which Kubernetes is deployed.


### PR DESCRIPTION
<!--
Thank you for contributing to appuio/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

-->

#### What this PR does / why we need it:

This PR updates the default `wrestic` version in k8up to the latest release of today, which fixes some important bugs that improve the overall reliablility of k8up operations.

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] [DCO](https://github.com/appuio/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR contains starts with chart name e.g. `[chart]`
