### PR TITLE
[haproxy] Add support to expose backend metrics in haproxy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,9 +45,9 @@ lint\:vet: ## Run go vet against code
 lint\:versions: ## Checks if chart versions have been changed
 	@echo --- Detecting version bumps in the charts
 	@echo "    If this target fails, one of the listed charts below has not its version updated!"
-	@changed_dirs=$$(git diff --dirstat=files,0 origin/master..HEAD -- appuio | awk '{if (!/\.github/) print $$2}') ; \
-	  echo $$changed_dirs ; echo ;  \
-	  for dir in $$changed_dirs; do git diff origin/master..HEAD -- "$${dir}Chart.yaml" | grep -H --label=$$dir "+version"; done
+	@changed_charts=$$(git diff --dirstat=files,0 origin/master..HEAD -- appuio | cut -d '/' -f 2 | uniq) ; \
+	  echo $$changed_charts ; echo ;  \
+	  for dir in $$changed_charts; do git diff origin/master..HEAD -- "appuio/$${dir}/Chart.yaml" | grep -H --label=$${dir} "+version"; done
 
 .PHONY: lint
 lint: lint\:fmt lint\:vet ## All-in-one linting and checks for uncommitted changes

--- a/appuio/haproxy/Chart.yaml
+++ b/appuio/haproxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 2.3.5
 description: A Helm chart for HAProxy which can be customized by a config map.
 name: haproxy
-version: 1.3.8
+version: 1.4.0
 maintainers:
   - name: APPUiO Team
     email: info@appuio.ch

--- a/appuio/haproxy/README.gotmpl.md
+++ b/appuio/haproxy/README.gotmpl.md
@@ -112,6 +112,7 @@ Set `haproxy.config` to `galerak8s` to use the Galera configuration with DNS ser
 | `haproxy.galerak8s.dnsservicename` | The DNS Record for service discovery | `mycluster-mariadb-galera-headless`
 | `haproxy.galerak8s.nodeCount` | Max number of nodes in the backend | `3`
 | `haproxy.galerak8s.port` | Port of the Galera node | `3306`
+| `haproxy.galerak8s.metrics.enabled`| If the metric endpoint of the Galera backends should be exposed in haproxy | `false`
 
 ### redisk8s
 
@@ -127,3 +128,19 @@ Set `haproxy.config` to `redisk8s` to use the Redis configuration with DNS servi
 | `haproxy.redisk8s.dnsservicename` | The DNS Record for service discovery | `redis-access-headless`
 | `haproxy.redisk8s.nodeCount` | Max number of nodes in the backend | `3`
 | `haproxy.redisk8s.port` | Port of the Galera node | `6379`
+| `haproxy.redisk8s.metrics.enabled`| If the metric endpoint of the Redis backends should be exposed in haproxy | `false`
+
+
+## Galera and Redis metrics
+
+By setting the `haproxy.galerak8s.metrics.enabled` or `haproxy.redisk8s.metrics.enabled` parameters, you can expose the metrics of the backend pods.
+
+For Galera the endpoints are:
+* `<haproxy_service_ip>:9090/metrics/mariadb-0/metrics`
+* `<haproxy_service_ip>:9090/metrics/mariadb-1/metrics`
+* `...`
+
+For Redis the endpoints are:
+* `<haproxy_service_ip>:9090/metrics/redis-0/metrics`
+* `<haproxy_service_ip>:9090/metrics/redis-1/metrics`
+* `...`

--- a/appuio/haproxy/README.md
+++ b/appuio/haproxy/README.md
@@ -1,6 +1,6 @@
 # haproxy
 
-![Version: 1.3.8](https://img.shields.io/badge/Version-1.3.8-informational?style=flat-square) ![AppVersion: 2.3.5](https://img.shields.io/badge/AppVersion-2.3.5-informational?style=flat-square)
+![Version: 1.4.0](https://img.shields.io/badge/Version-1.4.0-informational?style=flat-square) ![AppVersion: 2.3.5](https://img.shields.io/badge/AppVersion-2.3.5-informational?style=flat-square)
 
 A Helm chart for HAProxy which can be customized by a config map.
 
@@ -122,6 +122,7 @@ Set `haproxy.config` to `galerak8s` to use the Galera configuration with DNS ser
 | `haproxy.galerak8s.dnsservicename` | The DNS Record for service discovery | `mycluster-mariadb-galera-headless`
 | `haproxy.galerak8s.nodeCount` | Max number of nodes in the backend | `3`
 | `haproxy.galerak8s.port` | Port of the Galera node | `3306`
+| `haproxy.galerak8s.metrics.enabled`| If the metric endpoint of the Galera backends should be exposed in haproxy | `false`
 
 ### redisk8s
 
@@ -137,6 +138,21 @@ Set `haproxy.config` to `redisk8s` to use the Redis configuration with DNS servi
 | `haproxy.redisk8s.dnsservicename` | The DNS Record for service discovery | `redis-access-headless`
 | `haproxy.redisk8s.nodeCount` | Max number of nodes in the backend | `3`
 | `haproxy.redisk8s.port` | Port of the Galera node | `6379`
+| `haproxy.redisk8s.metrics.enabled`| If the metric endpoint of the Redis backends should be exposed in haproxy | `false`
+
+## Galera and Redis metrics
+
+By setting the `haproxy.galerak8s.metrics.enabled` or `haproxy.redisk8s.metrics.enabled` parameters, you can expose the metrics of the backend pods.
+
+For Galera the endpoints are:
+* `<haproxy_service_ip>:9090/metrics/mariadb-0/metrics`
+* `<haproxy_service_ip>:9090/metrics/mariadb-1/metrics`
+* `...`
+
+For Redis the endpoints are:
+* `<haproxy_service_ip>:9090/metrics/redis-0/metrics`
+* `<haproxy_service_ip>:9090/metrics/redis-1/metrics`
+* `...`
 
 <!---
 Common/Useful Link references from values.yaml

--- a/appuio/haproxy/templates/configmap-galerak8s.yaml
+++ b/appuio/haproxy/templates/configmap-galerak8s.yaml
@@ -32,6 +32,8 @@ data:
       option clitcpka
       default_backend galera-nodes
 
+    {{- include "haproxy.galeraMetricsConfig" . | nindent 4 }}
+
     backend galera-nodes
       mode tcp
       option srvtcpka

--- a/appuio/haproxy/templates/configmap-redisk8s.yaml
+++ b/appuio/haproxy/templates/configmap-redisk8s.yaml
@@ -32,6 +32,8 @@ data:
       option clitcpka
       default_backend redis-nodes
 
+    {{- include "haproxy.redisMetricsConfig" . | nindent 4 }}
+
     backend redis-nodes
       mode tcp
 

--- a/appuio/haproxy/templates/deployment.yaml
+++ b/appuio/haproxy/templates/deployment.yaml
@@ -40,6 +40,10 @@ spec:
             - name: metrics
               containerPort: 9000
             {{- end }}
+            {{- if or .Values.haproxy.redisk8s.metrics.enabled .Values.haproxy.galerak8s.metrics.enabled}}
+            - name: metrics-backend
+              containerPort: 9090
+            {{- end }}
           readinessProbe:
           {{- if .Values.metrics.enabled }}
             httpGet:

--- a/appuio/haproxy/templates/service.yaml
+++ b/appuio/haproxy/templates/service.yaml
@@ -14,9 +14,16 @@ spec:
       targetPort: {{ .Values.haproxy.frontendPort }}
       protocol: TCP
       name: frontend
+    {{- if or .Values.haproxy.redisk8s.metrics.enabled .Values.haproxy.galerak8s.metrics.enabled}}
+    - port: 9090
+      targetPort: metrics-backend
+      protocol: TCP
+      name: metrics-backend
+    {{- end }}
     {{- if .Values.service.additionalPorts }}
 {{ toYaml .Values.service.additionalPorts | indent 4 }}
     {{- end }}
   selector:
     app.kubernetes.io/name: {{ include "haproxy.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+    

--- a/appuio/haproxy/values.yaml
+++ b/appuio/haproxy/values.yaml
@@ -11,12 +11,12 @@ ingress:
   annotations: {}
     # kubernetes.io/ingress.class: haproxy
     # kubernetes.io/tls-acme: "true"
-  
+
   ## Hosts for the ingress
   hosts:
     # - one.example.org
     # - two.example.org
-  
+
   ## TLS configuration
   tls:
     enabled: true
@@ -24,7 +24,6 @@ ingress:
 
 ## Extra sidecar containers to add to the deployment
 sidecarContainers: []
-
 
 ## Affinity for pod assignment. Evaluated as a template.
 ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
@@ -42,9 +41,9 @@ haproxy:
   frontendPort: 30636
 
   check:
-    existingSecret: 
+    existingSecret:
       name: "" # Use existing secret with authentication credentials for checks.
-      key: "auth-credentials" 
+      key: "auth-credentials"
 
   securityContext: {}
     # runAsUser: 1000
@@ -84,6 +83,8 @@ haproxy:
     dnsservicename: mycluster-mariadb-galera-headless
     port: 3306
     nodeCount: 3
+    metrics:
+      enabled: false
 
   redisk8s:
     timeout:
@@ -97,6 +98,8 @@ haproxy:
     dnsservicename: redis-access-headless
     port: 6379
     nodeCount: 3
+    metrics:
+      enabled: false
 
 metrics:
   enabled: true
@@ -135,7 +138,7 @@ metrics:
     #   expr: haproxy_backend_active_servers{proxy="redis"} < 1
     #   for: 15s
     #   labels:
-    #     severity: page      
+    #     severity: page
     #   annotations:
     #     summary: HAProxy reports all servers are unhealthy for redis.
     rules: []
@@ -157,8 +160,8 @@ podDisruptionBudget:
 
 resources:
   limits:
-   cpu: 100m
-   memory: 128Mi
+    cpu: 100m
+    memory: 128Mi
   requests:
-   cpu: 100m
-   memory: 128Mi
+    cpu: 100m
+    memory: 128Mi


### PR DESCRIPTION
This commit allows to expose the Galera and Redis metrics via haproxy so
they can be scraped by any prometheus instance.

They are exposed via the haproxy service of type `LoadBalancer`.
For galera the endpoints are:
* <haproxy_service_ip>:/metrics/mariadb-0/metrics
* <haproxy_service_ip>:/metrics/mariadb-1/metrics
* <haproxy_service_ip>:/metrics/mariadb-2/metrics

For redis the endpoints are:
* <haproxy_service_ip>:/metrics/redis-0/metrics
* <haproxy_service_ip>:/metrics/redis-1/metrics
* <haproxy_service_ip>:/metrics/redis-2/metrics

<!--
Thank you for contributing to appuio/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

-->

#### What this PR does / why we need it:

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] [DCO](https://github.com/appuio/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
- [x] Title of the PR contains starts with chart name e.g. `[chart]`
