### PR TITLE
[k8up] Add "backup failed" alert based on kube_job_status_failed

### DIFF
--- a/appuio/k8up/Chart.yaml
+++ b/appuio/k8up/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - backup
   - operator
   - restic
-version: 1.0.9
+version: 1.1.0
 appVersion: v1.1.0
 sources:
   - https://github.com/vshn/k8up

--- a/appuio/k8up/Chart.yaml
+++ b/appuio/k8up/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
   - operator
   - restic
 version: 1.1.0
-appVersion: v1.1.0
+appVersion: v1.2.0
 sources:
   - https://github.com/vshn/k8up
   - https://github.com/vshn/wrestic

--- a/appuio/k8up/README.md
+++ b/appuio/k8up/README.md
@@ -1,6 +1,6 @@
 # k8up
 
-![Version: 1.0.9](https://img.shields.io/badge/Version-1.0.9-informational?style=flat-square) ![AppVersion: v1.1.0](https://img.shields.io/badge/AppVersion-v1.1.0-informational?style=flat-square)
+![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![AppVersion: v1.1.0](https://img.shields.io/badge/AppVersion-v1.1.0-informational?style=flat-square)
 
 Kubernetes and OpenShift Backup Operator based on restic
 
@@ -65,6 +65,7 @@ Document your changes in values.yaml and let `make docs:helm` generate this sect
 | metrics.prometheusRule.additionalRules | list | `[]` | Provide additional alert rules in addition to the defaults |
 | metrics.prometheusRule.createDefaultRules | bool | `true` | Whether the default rules should be installed |
 | metrics.prometheusRule.enabled | bool | `false` | Whether to enable PrometheusRule manifest for [Prometheus Operator][prometheus-operator] |
+| metrics.prometheusRule.legacyRules | bool | `false` | Create default rules for kube-state-metrics < v1.5.0 Needed for OpenShift 3.x |
 | metrics.prometheusRule.namespace | string | `""` | If the object should be installed in a different namespace than operator |
 | metrics.service.nodePort | int | `0` | Service node port of the metrics endpoint, requires `metrics.service.type=NodePort` |
 | metrics.service.port | int | `8080` |  |

--- a/appuio/k8up/README.md
+++ b/appuio/k8up/README.md
@@ -65,6 +65,7 @@ Document your changes in values.yaml and let `make docs:helm` generate this sect
 | metrics.prometheusRule.additionalRules | list | `[]` | Provide additional alert rules in addition to the defaults |
 | metrics.prometheusRule.createDefaultRules | bool | `true` | Whether the default rules should be installed |
 | metrics.prometheusRule.enabled | bool | `false` | Whether to enable PrometheusRule manifest for [Prometheus Operator][prometheus-operator] |
+| metrics.prometheusRule.jobFailedRulesFor | list | `["archive","backup","check","prune","restore"]` | Create default rules for the given job types. Valid values are "archive", "backup", "check", "prune", and "restore". |
 | metrics.prometheusRule.legacyRules | bool | `false` | Create default rules for kube-state-metrics < v1.5.0 Needed for OpenShift 3.x |
 | metrics.prometheusRule.namespace | string | `""` | If the object should be installed in a different namespace than operator |
 | metrics.service.nodePort | int | `0` | Service node port of the metrics endpoint, requires `metrics.service.type=NodePort` |

--- a/appuio/k8up/README.md
+++ b/appuio/k8up/README.md
@@ -1,6 +1,6 @@
 # k8up
 
-![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![AppVersion: v1.1.0](https://img.shields.io/badge/AppVersion-v1.1.0-informational?style=flat-square)
+![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![AppVersion: v1.2.0](https://img.shields.io/badge/AppVersion-v1.2.0-informational?style=flat-square)
 
 Kubernetes and OpenShift Backup Operator based on restic
 
@@ -14,9 +14,9 @@ helm install k8up appuio/k8up
 ```
 ```bash
 # Install CRDs for K8s >= 1.16:
-kubectl apply -f https://github.com/vshn/k8up/releases/download/v1.1.0/k8up-crd.yaml
+kubectl apply -f https://github.com/vshn/k8up/releases/download/v1.2.0/k8up-crd.yaml
 # Install CRDs for K8s <= 1.15 (e.g. OpenShift 3.11):
-kubectl apply -f https://github.com/vshn/k8up/releases/download/v1.1.0/k8up-crd-legacy.yaml
+kubectl apply -f https://github.com/vshn/k8up/releases/download/v1.2.0/k8up-crd-legacy.yaml
 ```
 
 <!---
@@ -48,7 +48,7 @@ Document your changes in values.yaml and let `make docs:helm` generate this sect
 | image.pullPolicy | string | `"IfNotPresent"` | Operator image pull policy |
 | image.registry | string | `"quay.io"` | Operator image registry |
 | image.repository | string | `"vshn/k8up"` | Operator image repository |
-| image.tag | string | `"v1.1.0"` | Operator image tag (version) |
+| image.tag | string | `"v1.2.0"` | Operator image tag (version) |
 | imagePullSecrets | list | `[]` |  |
 | k8up.backupImage.repository | string | `"quay.io/vshn/wrestic"` | The backup runner image repository |
 | k8up.backupImage.tag | string | `"v0.3.2"` | The backup runner image tag |

--- a/appuio/k8up/rbac-kustomize/kustomization.yaml
+++ b/appuio/k8up/rbac-kustomize/kustomization.yaml
@@ -1,5 +1,5 @@
 resources:
-  - github.com/vshn/k8up/config/rbac?ref=v1.1.0
+  - github.com/vshn/k8up/config/rbac?ref=v1.2.0
 
 namePrefix: PREFIX-
 namespace: "{{ .Release.Namespace }}"

--- a/appuio/k8up/templates/prometheus/prometheusrule.yaml
+++ b/appuio/k8up/templates/prometheus/prometheusrule.yaml
@@ -37,7 +37,7 @@ spec:
             severity: critical
           annotations:
             summary: "K8up jobs are stuck in {{ "{{ $labels.namespace }}" }} for the last 24 hours."
-        {{- range tuple "archive" "backup" "check" "prune" "restore" }}
+        {{- range .Values.metrics.prometheusRule.jobFailedRulesFor }}
         - alert: K8up{{- . | title -}}Failed
           expr: (sum(kube_job_status_failed) by({{ $jobNameLabel }}, namespace) * on({{ $jobNameLabel }}, namespace) group_right() kube_job_labels{label_k8up_syn_tools_type="{{- . -}}"}) > 0
           for: 1m

--- a/appuio/k8up/templates/prometheus/prometheusrule.yaml
+++ b/appuio/k8up/templates/prometheus/prometheusrule.yaml
@@ -1,4 +1,5 @@
 {{- if and .Values.metrics.prometheusRule.enabled (or .Values.metrics.prometheusRule.createDefaultRules .Values.metrics.prometheusRule.additionalRules) -}}
+{{- $jobNameLabel := ternary "job" "job_name" .Values.metrics.prometheusRule.legacyRules -}}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
@@ -22,13 +23,6 @@ spec:
           annotations:
             summary: Amount of errors of last restic backup
             description: This alert is fired when error number is > 0
-        - alert: K8upBackupFailed
-          expr: rate(k8up_jobs_failed_counter[1d]) > 0
-          for: 1m
-          labels:
-            severity: critical
-          annotations:
-            summary: "Job in {{ "{{ $labels.namespace }}" }} of type {{ "{{ $labels.jobType }}" }} failed"
         - alert: K8upBackupNotRunning
           expr: sum(rate(k8up_jobs_total[25h])) == 0 and on(namespace) k8up_schedules_gauge > 0
           for: 1m
@@ -43,6 +37,15 @@ spec:
             severity: critical
           annotations:
             summary: "K8up jobs are stuck in {{ "{{ $labels.namespace }}" }} for the last 24 hours."
+        {{- range tuple "archive" "backup" "check" "prune" "restore" }}
+        - alert: K8up{{- . | title -}}Failed
+          expr: (sum(kube_job_status_failed) by({{ $jobNameLabel }}, namespace) * on({{ $jobNameLabel }}, namespace) group_right() kube_job_labels{label_k8up_syn_tools_type="{{- . -}}"}) > 0
+          for: 1m
+          labels:
+            severity: critical
+          annotations:
+            summary: "Job in {{ "{{ $labels.namespace }}" }} of type {{ "{{ $labels.label_k8up_syn_tools_type }}" }} failed"
+        {{- end }}
         {{- end }}
         {{- with .Values.metrics.prometheusRule.additionalRules }}
         {{- toYaml . | nindent 8 }}

--- a/appuio/k8up/test/prometheus/prometheusrule_test.go
+++ b/appuio/k8up/test/prometheus/prometheusrule_test.go
@@ -72,6 +72,26 @@ func Test_PrometheusRule_GivenEnabled_WhenCreateDefaultRulesEnabled_ThenRenderDe
 	assert.GreaterOrEqual(t, len(rule.Spec.Groups[0].Rules), 4)
 }
 
+func Test_PrometheusRule_GivenEnabled_ConfigureEnabledRules(t *testing.T) {
+	renderWithRulesFor := func(rules []string) []monitoringv1.Rule {
+		options := &helm.Options{
+			SetValues: map[string]string{
+				"metrics.prometheusRule.enabled":           "true",
+				"metrics.prometheusRule.jobFailedRulesFor": "{" + strings.Join(rules, ",") + "}",
+			},
+		}
+		output := helm.RenderTemplate(t, options, helmChartPath, releaseName, tplPrometheusRule)
+		rule := monitoringv1.PrometheusRule{}
+		helm.UnmarshalK8SYaml(t, output, &rule)
+		return rule.Spec.Groups[0].Rules
+	}
+
+	rules := []string{"backup"}
+	assert.Len(t, findFailedRules(renderWithRulesFor(rules)), 1)
+	rules = append(rules, "restore", "prune")
+	assert.Len(t, findFailedRules(renderWithRulesFor(rules)), 3)
+}
+
 var legacyRuleSubjects = map[string]struct {
 	legacyRulesEnabled  bool
 	expectRuleToContain string
@@ -98,18 +118,9 @@ func Test_PrometheusRule_GivenEnabled_LegacyRules(t *testing.T) {
 			rule := monitoringv1.PrometheusRule{}
 			helm.UnmarshalK8SYaml(t, output, &rule)
 
-			findFailedRule := func(rules []monitoringv1.Rule) *monitoringv1.Rule {
-				for _, rule := range rules {
-					if strings.HasSuffix(rule.Alert, "Failed") {
-						return &rule
-					}
-				}
-				return nil
-			}
-
-			failedRule := findFailedRule(rule.Spec.Groups[0].Rules)
-			assert.NotNil(t, failedRule)
-			assert.Contains(t, failedRule.Expr.String(), tC.expectRuleToContain)
+			failedRules := findFailedRules(rule.Spec.Groups[0].Rules)
+			assert.NotEmpty(t, failedRules)
+			assert.Contains(t, failedRules[0].Expr.String(), tC.expectRuleToContain)
 		})
 	}
 }
@@ -154,4 +165,14 @@ func Test_PrometheusRule_GivenEnabled_WhenCreateDefaultRulesEnabledAndAdditional
 	amount := len(rule.Spec.Groups[0].Rules)
 	assert.GreaterOrEqual(t, amount, 2)
 	assert.Equal(t, "MyCustomRule", rule.Spec.Groups[0].Rules[amount-1].Alert)
+}
+
+func findFailedRules(rules []monitoringv1.Rule) []monitoringv1.Rule {
+	failedRules := make([]monitoringv1.Rule, 0, len(rules))
+	for _, rule := range rules {
+		if strings.HasSuffix(rule.Alert, "Failed") {
+			failedRules = append(failedRules, rule)
+		}
+	}
+	return failedRules
 }

--- a/appuio/k8up/test/prometheus/prometheusrule_test.go
+++ b/appuio/k8up/test/prometheus/prometheusrule_test.go
@@ -1,6 +1,8 @@
 package test
 
 import (
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -68,6 +70,48 @@ func Test_PrometheusRule_GivenEnabled_WhenCreateDefaultRulesEnabled_ThenRenderDe
 
 	assert.NotEmpty(t, rule.Spec.Groups[0].Rules)
 	assert.GreaterOrEqual(t, len(rule.Spec.Groups[0].Rules), 4)
+}
+
+var legacyRuleSubjects = map[string]struct {
+	legacyRulesEnabled  bool
+	expectRuleToContain string
+}{
+	"WhenLegacyRulesDisabled_ThenRenderNormalRule": {
+		true, "by(job,",
+	},
+	"WhenLegacyRulesEnabled_ThenRenderLegacyRule": {
+		false, "by(job_name,",
+	},
+}
+
+func Test_PrometheusRule_GivenEnabled_LegacyRules(t *testing.T) {
+	for descr, tC := range legacyRuleSubjects {
+		t.Run(descr, func(t *testing.T) {
+			options := &helm.Options{
+				SetValues: map[string]string{
+					"metrics.prometheusRule.enabled":     "true",
+					"metrics.prometheusRule.legacyRules": strconv.FormatBool(tC.legacyRulesEnabled),
+				},
+			}
+
+			output := helm.RenderTemplate(t, options, helmChartPath, releaseName, tplPrometheusRule)
+			rule := monitoringv1.PrometheusRule{}
+			helm.UnmarshalK8SYaml(t, output, &rule)
+
+			findFailedRule := func(rules []monitoringv1.Rule) *monitoringv1.Rule {
+				for _, rule := range rules {
+					if strings.HasSuffix(rule.Alert, "Failed") {
+						return &rule
+					}
+				}
+				return nil
+			}
+
+			failedRule := findFailedRule(rule.Spec.Groups[0].Rules)
+			assert.NotNil(t, failedRule)
+			assert.Contains(t, failedRule.Expr.String(), tC.expectRuleToContain)
+		})
+	}
 }
 
 func Test_PrometheusRule_GivenEnabled_WhenCreateDefaultRulesDisabled_ThenRenderNoTemplate(t *testing.T) {

--- a/appuio/k8up/values.yaml
+++ b/appuio/k8up/values.yaml
@@ -104,6 +104,9 @@ metrics:
     # -- Create default rules for kube-state-metrics < v1.5.0
     # Needed for OpenShift 3.x
     legacyRules: false
+    # -- Create default rules for the given job types.
+    # Valid values are "archive", "backup", "check", "prune", and "restore".
+    jobFailedRulesFor: ["archive", "backup", "check", "prune", "restore"]
     # -- Provide additional alert rules in addition to the defaults
     additionalRules: []
 

--- a/appuio/k8up/values.yaml
+++ b/appuio/k8up/values.yaml
@@ -101,6 +101,9 @@ metrics:
     additionalLabels: {}
     # -- Whether the default rules should be installed
     createDefaultRules: true
+    # -- Create default rules for kube-state-metrics < v1.5.0
+    # Needed for OpenShift 3.x
+    legacyRules: false
     # -- Provide additional alert rules in addition to the defaults
     additionalRules: []
 

--- a/appuio/k8up/values.yaml
+++ b/appuio/k8up/values.yaml
@@ -10,7 +10,7 @@ image:
   # -- Operator image repository
   repository: vshn/k8up
   # -- Operator image tag (version)
-  tag: v1.1.0
+  tag: v1.2.0
 
 imagePullSecrets: []
 serviceAccount:


### PR DESCRIPTION
<!--
Thank you for contributing to appuio/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

-->

#### What this PR does / why we need it:

This change allows to stop firing the alert quicker if failed jobs are cleaned.


#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] [DCO](https://github.com/appuio/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] Title of the PR contains starts with chart name e.g. `[chart]`
