### PR TITLE
[stardog] Add more stardog monitoring rules

### DIFF
--- a/appuio/stardog/Chart.yaml
+++ b/appuio/stardog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: stardog
-version: 0.7.3
+version: 0.7.4
 appVersion: 7.6.4
 description: Stardog is the world’s leading knowledge graph platform for the enterprise. Stardog makes it fast and easy to turn enterprise data into knowledge.
 home: "https://www.stardog.com/"

--- a/appuio/stardog/README.md
+++ b/appuio/stardog/README.md
@@ -1,6 +1,6 @@
 # stardog
 
-![Version: 0.7.3](https://img.shields.io/badge/Version-0.7.3-informational?style=flat-square) ![AppVersion: 7.6.4](https://img.shields.io/badge/AppVersion-7.6.4-informational?style=flat-square)
+![Version: 0.7.4](https://img.shields.io/badge/Version-0.7.4-informational?style=flat-square) ![AppVersion: 7.6.4](https://img.shields.io/badge/AppVersion-7.6.4-informational?style=flat-square)
 
 Stardog is the world’s leading knowledge graph platform for the enterprise. Stardog makes it fast and easy to turn enterprise data into knowledge.
 

--- a/appuio/stardog/templates/monitoring/stardog-rules.yaml
+++ b/appuio/stardog/templates/monitoring/stardog-rules.yaml
@@ -44,4 +44,25 @@ spec:
         env: {{ .Release.Name }}
         app: stardog
         severity: "{{ "{{ if lt $value 2.0 }}" }}critical{{ "{{ else }}" }}warning{{ "{{ end }}" }}"
+    {{- if .Values.ingress.enabled }}
+    - alert: HttpCheck
+      expr: probe_success{instance="https://{{ .Values.ingress.host }}/admin/healthcheck"} != 1
+      for: 1m
+      annotations:
+        summary: Http check failed
+        description: "Http check failed on {{ "{{" }} $labels.instance {{ "}}" }}"
+      labels:
+        env: {{ .Release.Name }}
+        severity: critical
+        oncall: "{{ "{{ if eq $labels.env \\\"prod\\\" }}" }}true{{ "{{ else }}" }}false{{" {{ end }} "}}"
+    - alert: CertExpirySoon
+      expr: probe_ssl_earliest_cert_expiry{instance="https://{{ .Values.ingress.host }}/admin/healthcheck"} - time() < 86400 * 30
+      for: 10m
+      annotations:
+        summary: SSL ertificate expires in less than 30 days
+        description: "SSL certificate on {{ "{{" }} $labels.instance {{ "}}" }} expires is in less than 30 days"
+      labels:
+        env: {{ .Release.Name }}
+        severity: warning
+    {{- end }}
 {{- end }}


### PR DESCRIPTION
Signed-off-by: Gabriel Saratura <gabriel.saratura@vshn.ch>

#### What this PR does / why we need it:

Added http checks for stardog. The metrics are exported via blackbox

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] [DCO](https://github.com/appuio/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] Title of the PR contains starts with chart name e.g. `[chart]`
