### PR TITLE
[stardog] Disable backup restore testing

### DIFF
--- a/appuio/stardog/Chart.yaml
+++ b/appuio/stardog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: stardog
-version: 0.7.7
+version: 0.7.8
 appVersion: 7.7.2
 description: Stardog is the world’s leading knowledge graph platform for the enterprise. Stardog makes it fast and easy to turn enterprise data into knowledge.
 home: "https://www.stardog.com/"

--- a/appuio/stardog/README.md
+++ b/appuio/stardog/README.md
@@ -1,6 +1,6 @@
 # stardog
 
-![Version: 0.7.7](https://img.shields.io/badge/Version-0.7.7-informational?style=flat-square) ![AppVersion: 7.7.2](https://img.shields.io/badge/AppVersion-7.7.2-informational?style=flat-square)
+![Version: 0.7.8](https://img.shields.io/badge/Version-0.7.8-informational?style=flat-square) ![AppVersion: 7.7.2](https://img.shields.io/badge/AppVersion-7.7.2-informational?style=flat-square)
 
 Stardog is the world’s leading knowledge graph platform for the enterprise. Stardog makes it fast and easy to turn enterprise data into knowledge.
 

--- a/appuio/stardog/templates/cronjob.yaml
+++ b/appuio/stardog/templates/cronjob.yaml
@@ -70,21 +70,9 @@ spec:
               set -e
               BACKUP_DATE=$(date --utc +%Y-%m-%d_%H%M)
               DATABASE_NAME={{ $db.name | quote }}
-              #CURRENT_TRIPLE_COUNT=$(/opt/stardog/bin/stardog data size --exact "${DATABASE_NAME}" --passwd "${STARDOG_ADMIN_PW}" | cut -d " " -f 2 | tr -d ",")
               echo "${DATABASE_NAME} has ${CURRENT_TRIPLE_COUNT} triples."
               BACKUP_TARGET="s3://${S3_ENDPOINT}/${S3_BUCKET_NAME}/${S3_PATH_PREFIX}/${BACKUP_DATE}?AWS_ACCESS_KEY_ID=${S3_ACCESS_KEY}&AWS_SECRET_ACCESS_KEY=${S3_SECRET_KEY}&region=${S3_REGION}"
-              #/opt/stardog/bin/stardog-admin db status --passwd "${STARDOG_ADMIN_PW}" "${DATABASE_NAME}"
               /opt/stardog/bin/stardog-admin db backup --passwd "${STARDOG_ADMIN_PW}" --to "${BACKUP_TARGET}" "${DATABASE_NAME}"
-              #PERCENT_USE=$(df --output=pcent -h /var/opt/stardog | tail -n 1 | tr -d "%")
-              #if [ "${PERCENT_USE}" -gt "60" ]; then echo "not enough space to test restore: ${PERCENT_USE}% used" ; exit 1; fi
-              #RESTORE_TARGET="s3://${S3_ENDPOINT}/${S3_BUCKET_NAME}/${S3_PATH_PREFIX}/${BACKUP_DATE}/${DATABASE_NAME}?AWS_ACCESS_KEY_ID=${S3_ACCESS_KEY}&AWS_SECRET_ACCESS_KEY=${S3_SECRET_KEY}&region=${S3_REGION}"
-              #RESTORE_NAME="${DATABASE_NAME}_restore_test_${BACKUP_DATE}"
-              #/opt/stardog/bin/stardog-admin db restore --passwd "${STARDOG_ADMIN_PW}" --name "${RESTORE_NAME}" "${RESTORE_TARGET}"
-              #RESTORED_TRIPLE_COUNT=$(/opt/stardog/bin/stardog data size --exact "${RESTORE_NAME}" --passwd "${STARDOG_ADMIN_PW}" | cut -d " " -f 2 | tr -d ",")
-              #echo "After backup-and-restore: ${RESTORED_TRIPLE_COUNT} triples."
-              #/opt/stardog/bin/stardog-admin db drop --passwd "${STARDOG_ADMIN_PW}" "${RESTORE_NAME}"
-              #SAME_COUNT=$((${CURRENT_TRIPLE_COUNT} == ${RESTORED_TRIPLE_COUNT} ? 0 : 1 ))
-              #exit ${SAME_COUNT}
             volumeMounts:
             - name: data
               mountPath: /var/opt/stardog

--- a/appuio/stardog/templates/cronjob.yaml
+++ b/appuio/stardog/templates/cronjob.yaml
@@ -70,21 +70,21 @@ spec:
               set -e
               BACKUP_DATE=$(date --utc +%Y-%m-%d_%H%M)
               DATABASE_NAME={{ $db.name | quote }}
-              CURRENT_TRIPLE_COUNT=$(/opt/stardog/bin/stardog data size --exact "${DATABASE_NAME}" --passwd "${STARDOG_ADMIN_PW}" | cut -d " " -f 2 | tr -d ",")
+              #CURRENT_TRIPLE_COUNT=$(/opt/stardog/bin/stardog data size --exact "${DATABASE_NAME}" --passwd "${STARDOG_ADMIN_PW}" | cut -d " " -f 2 | tr -d ",")
               echo "${DATABASE_NAME} has ${CURRENT_TRIPLE_COUNT} triples."
               BACKUP_TARGET="s3://${S3_ENDPOINT}/${S3_BUCKET_NAME}/${S3_PATH_PREFIX}/${BACKUP_DATE}?AWS_ACCESS_KEY_ID=${S3_ACCESS_KEY}&AWS_SECRET_ACCESS_KEY=${S3_SECRET_KEY}&region=${S3_REGION}"
-              /opt/stardog/bin/stardog-admin db status --passwd "${STARDOG_ADMIN_PW}" "${DATABASE_NAME}"
+              #/opt/stardog/bin/stardog-admin db status --passwd "${STARDOG_ADMIN_PW}" "${DATABASE_NAME}"
               /opt/stardog/bin/stardog-admin db backup --passwd "${STARDOG_ADMIN_PW}" --to "${BACKUP_TARGET}" "${DATABASE_NAME}"
-              PERCENT_USE=$(df --output=pcent -h /var/opt/stardog | tail -n 1 | tr -d "%")
-              if [ "${PERCENT_USE}" -gt "60" ]; then echo "not enough space to test restore: ${PERCENT_USE}% used" ; exit 1; fi
-              RESTORE_TARGET="s3://${S3_ENDPOINT}/${S3_BUCKET_NAME}/${S3_PATH_PREFIX}/${BACKUP_DATE}/${DATABASE_NAME}?AWS_ACCESS_KEY_ID=${S3_ACCESS_KEY}&AWS_SECRET_ACCESS_KEY=${S3_SECRET_KEY}&region=${S3_REGION}"
-              RESTORE_NAME="${DATABASE_NAME}_restore_test_${BACKUP_DATE}"
-              /opt/stardog/bin/stardog-admin db restore --passwd "${STARDOG_ADMIN_PW}" --name "${RESTORE_NAME}" "${RESTORE_TARGET}"
-              RESTORED_TRIPLE_COUNT=$(/opt/stardog/bin/stardog data size --exact "${RESTORE_NAME}" --passwd "${STARDOG_ADMIN_PW}" | cut -d " " -f 2 | tr -d ",")
-              echo "After backup-and-restore: ${RESTORED_TRIPLE_COUNT} triples."
-              /opt/stardog/bin/stardog-admin db drop --passwd "${STARDOG_ADMIN_PW}" "${RESTORE_NAME}"
-              SAME_COUNT=$((${CURRENT_TRIPLE_COUNT} == ${RESTORED_TRIPLE_COUNT} ? 0 : 1 ))
-              exit ${SAME_COUNT}
+              #PERCENT_USE=$(df --output=pcent -h /var/opt/stardog | tail -n 1 | tr -d "%")
+              #if [ "${PERCENT_USE}" -gt "60" ]; then echo "not enough space to test restore: ${PERCENT_USE}% used" ; exit 1; fi
+              #RESTORE_TARGET="s3://${S3_ENDPOINT}/${S3_BUCKET_NAME}/${S3_PATH_PREFIX}/${BACKUP_DATE}/${DATABASE_NAME}?AWS_ACCESS_KEY_ID=${S3_ACCESS_KEY}&AWS_SECRET_ACCESS_KEY=${S3_SECRET_KEY}&region=${S3_REGION}"
+              #RESTORE_NAME="${DATABASE_NAME}_restore_test_${BACKUP_DATE}"
+              #/opt/stardog/bin/stardog-admin db restore --passwd "${STARDOG_ADMIN_PW}" --name "${RESTORE_NAME}" "${RESTORE_TARGET}"
+              #RESTORED_TRIPLE_COUNT=$(/opt/stardog/bin/stardog data size --exact "${RESTORE_NAME}" --passwd "${STARDOG_ADMIN_PW}" | cut -d " " -f 2 | tr -d ",")
+              #echo "After backup-and-restore: ${RESTORED_TRIPLE_COUNT} triples."
+              #/opt/stardog/bin/stardog-admin db drop --passwd "${STARDOG_ADMIN_PW}" "${RESTORE_NAME}"
+              #SAME_COUNT=$((${CURRENT_TRIPLE_COUNT} == ${RESTORED_TRIPLE_COUNT} ? 0 : 1 ))
+              #exit ${SAME_COUNT}
             volumeMounts:
             - name: data
               mountPath: /var/opt/stardog


### PR DESCRIPTION
#### What this PR does / why we need it:

The current tactic of comparing restored triple counts to backed up triple counts has caused problems with phantom databases remaining in Stardog's memory for months, leading to cluster sync problems. We're now also seeing write lock acquisition failures during the backup jobs, especially when long transactions are happening, which makes it less likely to actually get a working backup at all, let alone a restore. Backups on one large database rarely succeed even after running for 22h.

The restore also puts a lot of additional IOPS/CPU load on all nodes that could be better spent serving production workloads. The nodes not only have to restore the backup but also recompute indexes afterwards.

Thirdly, according to Stardog this measure is no longer necessary since the bug causing partial backups is said to be fixed.

We propose to create a separate, non-clustered Stardog node to test restores against instead of using the cluster. Until that's ready, this PR wants to comment out the restore functionality to see if it fixes some of the cluster sync problems.


#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] [DCO](https://github.com/appuio/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] Title of the PR contains starts with chart name e.g. `[chart]`



Signed-off by: Ramón Cahenzli <ramon.cahenzli@vshn.ch>