### PR TITLE
Make spilling.max.file.length configurable

### DIFF
--- a/appuio/stardog/Chart.yaml
+++ b/appuio/stardog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: stardog
-version: 0.7.9
+version: 0.8.0
 appVersion: 7.7.2
 description: Stardog is the world’s leading knowledge graph platform for the enterprise. Stardog makes it fast and easy to turn enterprise data into knowledge.
 home: "https://www.stardog.com/"

--- a/appuio/stardog/README.gotmpl.md
+++ b/appuio/stardog/README.gotmpl.md
@@ -44,6 +44,7 @@ The following table lists the configurable parameters chart. For default values 
 | `stardog.backup.s3AccessKey`                 | S3 API access key id |
 | `stardog.backup.s3SecretKey`                 | S3 API access secret key |
 | `stardog.backup.s3CredentialsExistingSecret` | Optionally existing secret with S3 credentials |
+| `spillinghack.enabled`                       | Set dbms.spilling.max.file.length to 0 to work around a possible bug where databases with query.memory.exceeds.strategy set to `FINISH_QUERY_EXECUTION` still manage to spill. This is a server-wide setting and affects all databases |
 | `ingress.enabled`                            | If an ingress object should be created |
 | `ingress.annotations`                        | Annotations to set on the ingress object |
 | `ingress.host`                               | Host name which the ingress should resolve |

--- a/appuio/stardog/README.gotmpl.md
+++ b/appuio/stardog/README.gotmpl.md
@@ -44,7 +44,7 @@ The following table lists the configurable parameters chart. For default values 
 | `stardog.backup.s3AccessKey`                 | S3 API access key id |
 | `stardog.backup.s3SecretKey`                 | S3 API access secret key |
 | `stardog.backup.s3CredentialsExistingSecret` | Optionally existing secret with S3 credentials |
-| `spillinghack.enabled`                       | Set dbms.spilling.max.file.length to 0 to work around a possible bug where databases with query.memory.exceeds.strategy set to `FINISH_QUERY_EXECUTION` still manage to spill. This is a server-wide setting and affects all databases |
+| `stardog.memory.spilling_max_file_length`    | Configure the maximum file length when spilling data to disk |
 | `ingress.enabled`                            | If an ingress object should be created |
 | `ingress.annotations`                        | Annotations to set on the ingress object |
 | `ingress.host`                               | Host name which the ingress should resolve |

--- a/appuio/stardog/README.md
+++ b/appuio/stardog/README.md
@@ -1,6 +1,6 @@
 # stardog
 
-![Version: 0.7.9](https://img.shields.io/badge/Version-0.7.9-informational?style=flat-square) ![AppVersion: 7.7.2](https://img.shields.io/badge/AppVersion-7.7.2-informational?style=flat-square)
+![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![AppVersion: 7.7.2](https://img.shields.io/badge/AppVersion-7.7.2-informational?style=flat-square)
 
 Stardog is the world’s leading knowledge graph platform for the enterprise. Stardog makes it fast and easy to turn enterprise data into knowledge.
 

--- a/appuio/stardog/README.md
+++ b/appuio/stardog/README.md
@@ -58,6 +58,7 @@ The following table lists the configurable parameters chart. For default values 
 | `stardog.backup.s3AccessKey`                 | S3 API access key id |
 | `stardog.backup.s3SecretKey`                 | S3 API access secret key |
 | `stardog.backup.s3CredentialsExistingSecret` | Optionally existing secret with S3 credentials |
+| `spillinghack.enabled`                       | Set dbms.spilling.max.file.length to 0 to work around a possible bug where databases with query.memory.exceeds.strategy set to `FINISH_QUERY_EXECUTION` still manage to spill. This is a server-wide setting and affects all databases |
 | `ingress.enabled`                            | If an ingress object should be created |
 | `ingress.annotations`                        | Annotations to set on the ingress object |
 | `ingress.host`                               | Host name which the ingress should resolve |

--- a/appuio/stardog/README.md
+++ b/appuio/stardog/README.md
@@ -82,7 +82,7 @@ The following table lists the configurable parameters chart. For default values 
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | zookeeper | 2.2.4 |
+| https://charts.bitnami.com/bitnami | zookeeper | 5.14.4 |
 
 <!---
 Common/Useful Link references from values.yaml

--- a/appuio/stardog/README.md
+++ b/appuio/stardog/README.md
@@ -58,7 +58,7 @@ The following table lists the configurable parameters chart. For default values 
 | `stardog.backup.s3AccessKey`                 | S3 API access key id |
 | `stardog.backup.s3SecretKey`                 | S3 API access secret key |
 | `stardog.backup.s3CredentialsExistingSecret` | Optionally existing secret with S3 credentials |
-| `spillinghack.enabled`                       | Set dbms.spilling.max.file.length to 0 to work around a possible bug where databases with query.memory.exceeds.strategy set to `FINISH_QUERY_EXECUTION` still manage to spill. This is a server-wide setting and affects all databases |
+| `stardog.memory.spilling_max_file_length`    | Configure the maximum file length when spilling data to disk |
 | `ingress.enabled`                            | If an ingress object should be created |
 | `ingress.annotations`                        | Annotations to set on the ingress object |
 | `ingress.host`                               | Host name which the ingress should resolve |

--- a/appuio/stardog/requirements.lock
+++ b/appuio/stardog/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: zookeeper
   repository: https://charts.bitnami.com/bitnami
-  version: 2.2.4
-digest: sha256:22fb6ba0aa0df94516626a5857947b03bb1be6963bb3aa959f8b287bfbdae520
-generated: "2021-10-19T11:03:55.347431+03:00"
+  version: 5.14.4
+digest: sha256:13a0276f894f6e6d74de482084ac1bb11df201a626ec389c26ee59c8de4ab6bf
+generated: "2021-11-18T16:25:28.265918208+01:00"

--- a/appuio/stardog/requirements.yaml
+++ b/appuio/stardog/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
   - name: zookeeper
-    version: 2.2.4
+    version: 5.14.4
     repository: https://charts.bitnami.com/bitnami
     condition: zookeeper.enabled

--- a/appuio/stardog/templates/configmap.yaml
+++ b/appuio/stardog/templates/configmap.yaml
@@ -30,3 +30,7 @@ data:
     metrics.reporter=jmx
     metrics.jmx.remote.access=true
     {{- end }}
+
+    {{- if .Values.spillinghack.enabled }}
+    dbms.spilling.max.file.length=0
+    {{- end }}

--- a/appuio/stardog/templates/configmap.yaml
+++ b/appuio/stardog/templates/configmap.yaml
@@ -31,6 +31,6 @@ data:
     metrics.jmx.remote.access=true
     {{- end }}
 
-    {{- if .Values.spillinghack.enabled }}
-    dbms.spilling.max.file.length=0
+    {{- if .Values.memory.spilling_max_file_length }}
+    spilling.max.file.length={{ .Values.memory.spilling_max_file_length }}
     {{- end }}

--- a/appuio/stardog/values.yaml
+++ b/appuio/stardog/values.yaml
@@ -97,8 +97,8 @@ tolerations: []
 
 affinityTopologyKey: kubernetes.io/hostname
 
-spillinghack:
-  enabled: false
+memory:
+  spilling_max_file_length: 10G
 
 # Only applies when stardog's replicaCount is >= 2
 zookeeper:

--- a/appuio/stardog/values.yaml
+++ b/appuio/stardog/values.yaml
@@ -97,6 +97,9 @@ tolerations: []
 
 affinityTopologyKey: kubernetes.io/hostname
 
+spillinghack:
+  enabled: false
+
 # Only applies when stardog's replicaCount is >= 2
 zookeeper:
   enabled: true


### PR DESCRIPTION
#### What this PR does / why we need it:

The PR enables configuration of the `spilling.max.file.length` option (see [documentation](https://docs.stardog.com/operating-stardog/server-administration/server-configuration#spillingmaxfilelength)).

This can be necessary to work around an issue where Stardog spills despite having `FINISH_QUERY_EXECUTION` configured as `query.memory.exceeds.strategy`.

As a workaround, Stardog recommends setting `spilling.max.file.length` to 0 to physically prevent spilling for the whole server. By default, this option is set to 10G.


#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] [DCO](https://github.com/appuio/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] Title of the PR contains starts with chart name e.g. `[chart]`
