### PR TITLE
[k8up] Update K8up to v2.0.1

### DIFF
--- a/appuio/k8up/Chart.yaml
+++ b/appuio/k8up/Chart.yaml
@@ -6,8 +6,8 @@ keywords:
   - backup
   - operator
   - restic
-version: 2.0.0
-appVersion: v2.0.0
+version: 2.0.1
+appVersion: v2.0.1
 sources:
   - https://github.com/k8up-io/k8up
 maintainers:

--- a/appuio/k8up/README.md
+++ b/appuio/k8up/README.md
@@ -1,6 +1,6 @@
 # k8up
 
-![Version: 2.0.0](https://img.shields.io/badge/Version-2.0.0-informational?style=flat-square) ![AppVersion: v2.0.0](https://img.shields.io/badge/AppVersion-v2.0.0-informational?style=flat-square)
+![Version: 2.0.1](https://img.shields.io/badge/Version-2.0.1-informational?style=flat-square) ![AppVersion: v2.0.1](https://img.shields.io/badge/AppVersion-v2.0.1-informational?style=flat-square)
 
 Kubernetes and OpenShift Backup Operator based on restic
 
@@ -13,7 +13,7 @@ helm repo add appuio https://charts.appuio.ch
 helm install k8up appuio/k8up
 ```
 ```bash
-kubectl apply -f https://github.com/k8up-io/k8up/releases/download/v2.0.0/k8up-crd.yaml
+kubectl apply -f https://github.com/k8up-io/k8up/releases/download/v2.0.1/k8up-crd.yaml
 ```
 
 <!---
@@ -44,10 +44,10 @@ Document your changes in values.yaml and let `make docs:helm` generate this sect
 | image.pullPolicy | string | `"IfNotPresent"` | Operator image pull policy |
 | image.registry | string | `"ghcr.io"` | Operator image registry |
 | image.repository | string | `"k8up-io/k8up"` | Operator image repository |
-| image.tag | string | `"v2.0.0"` | Operator image tag (version) |
+| image.tag | string | `"v2.0.1"` | Operator image tag (version) |
 | imagePullSecrets | list | `[]` |  |
 | k8up.backupImage.repository | string | `"ghcr.io/k8up-io/k8up"` | The backup runner image repository |
-| k8up.backupImage.tag | string | `"v2.0.0"` | The backup runner image tag |
+| k8up.backupImage.tag | string | `"v2.0.1"` | The backup runner image tag |
 | k8up.enableLeaderElection | bool | `true` | Specifies whether leader election should be enabled. |
 | k8up.envVars | list | `[]` | envVars allows the specification of additional environment variables. See [values.yaml](values.yaml) how to specify See documentation which variables are supported. |
 | k8up.globalResources | object | empty values | Specify the resource requests and limits that the Pods should have when they are scheduled by K8up. You are still able to override those via K8up resources, but this gives cluster administrators custom defaults. |

--- a/appuio/k8up/rbac-kustomize/kustomization.yaml
+++ b/appuio/k8up/rbac-kustomize/kustomization.yaml
@@ -1,5 +1,5 @@
 resources:
-  - github.com/k8up-io/k8up/config/rbac?ref=v2.0.0
+  - github.com/k8up-io/k8up/config/rbac?ref=v2.0.1
 
 namePrefix: PREFIX-
 namespace: "{{ .Release.Namespace }}"

--- a/appuio/k8up/templates/prometheus/prometheusrule.yaml
+++ b/appuio/k8up/templates/prometheus/prometheusrule.yaml
@@ -15,7 +15,7 @@ spec:
       rules:
         {{- if .Values.metrics.prometheusRule.createDefaultRules }}
         - alert: K8upResticErrors
-          expr: baas_backup_restic_last_errors > 0
+          expr: k8up_backup_restic_last_errors > 0
           for: 1m
           labels:
             severity: critical

--- a/appuio/k8up/values.yaml
+++ b/appuio/k8up/values.yaml
@@ -10,7 +10,7 @@ image:
   # -- Operator image repository
   repository: k8up-io/k8up
   # -- Operator image tag (version)
-  tag: v2.0.0
+  tag: v2.0.1
 
 imagePullSecrets: []
 serviceAccount:
@@ -35,7 +35,7 @@ k8up:
     # -- The backup runner image repository
     repository: ghcr.io/k8up-io/k8up
     # -- The backup runner image tag
-    tag: v2.0.0
+    tag: v2.0.1
 
   # -- Specifies the timezone K8up is using for scheduling.
   # Empty value defaults to the timezone in which Kubernetes is deployed.


### PR DESCRIPTION
#### What this PR does / why we need it:

* Updates K8up to [v2.0.1](https://github.com/k8up-io/k8up/releases/tag/v2.0.1) (includes prometheus namespace change for metrics)

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] I have run `make docs`
- [x] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] Title of the PR contains starts with chart name e.g. `[chart]`
