### PR TITLE
[redis] Increase probe timeouts

### DIFF
--- a/appuio/redis/Chart.yaml
+++ b/appuio/redis/Chart.yaml
@@ -24,4 +24,4 @@ name: redis
 sources:
 - https://github.com/bitnami/bitnami-docker-redis
 - http://redis.io/
-version: 1.3.1
+version: 1.3.2

--- a/appuio/redis/README.md
+++ b/appuio/redis/README.md
@@ -1,6 +1,6 @@
 # redis
 
-![Version: 1.3.1](https://img.shields.io/badge/Version-1.3.1-informational?style=flat-square) ![AppVersion: 6.2.1](https://img.shields.io/badge/AppVersion-6.2.1-informational?style=flat-square)
+![Version: 1.3.2](https://img.shields.io/badge/Version-1.3.2-informational?style=flat-square) ![AppVersion: 6.2.1](https://img.shields.io/badge/AppVersion-6.2.1-informational?style=flat-square)
 
 Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 
@@ -66,7 +66,7 @@ Edit the README.gotmpl.md template instead.
 | master.readinessProbe.initialDelaySeconds | int | `5` |  |
 | master.readinessProbe.periodSeconds | int | `5` |  |
 | master.readinessProbe.successThreshold | int | `1` |  |
-| master.readinessProbe.timeoutSeconds | int | `1` |  |
+| master.readinessProbe.timeoutSeconds | int | `5` |  |
 | master.service.annotations | object | `{}` |  |
 | master.service.externalTrafficPolicy | string | `"Cluster"` | External traffic policy (when service type is LoadBalancer) |
 | master.service.labels | object | `{}` | Provide any additional labels |
@@ -158,7 +158,7 @@ Edit the README.gotmpl.md template instead.
 | sentinel.readinessProbe.initialDelaySeconds | int | `5` |  |
 | sentinel.readinessProbe.periodSeconds | int | `5` |  |
 | sentinel.readinessProbe.successThreshold | int | `1` |  |
-| sentinel.readinessProbe.timeoutSeconds | int | `1` |  |
+| sentinel.readinessProbe.timeoutSeconds | int | `5` |  |
 | sentinel.service.annotations | object | `{}` |  |
 | sentinel.service.externalTrafficPolicy | string | `"Cluster"` | External traffic policy (when service type is LoadBalancer) |
 | sentinel.service.labels | object | `{}` |  |

--- a/appuio/redis/values.yaml
+++ b/appuio/redis/values.yaml
@@ -118,7 +118,7 @@ sentinel:
     enabled: true
     initialDelaySeconds: 5
     periodSeconds: 5
-    timeoutSeconds: 1
+    timeoutSeconds: 5
     successThreshold: 1
     failureThreshold: 5
   customLivenessProbe: {}
@@ -439,7 +439,7 @@ master:
     enabled: true
     initialDelaySeconds: 5
     periodSeconds: 5
-    timeoutSeconds: 1
+    timeoutSeconds: 5
     successThreshold: 1
     failureThreshold: 5
 


### PR DESCRIPTION
With Kubernetes v1.20 a bug was fixed where exec probe timeouts were not
respected. This fix led to failing probes for Redis because the timeout
of 1s is actually too short.

<!--
Thank you for contributing to appuio/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

-->

#### What this PR does / why we need it:

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] I have run `make docs`
- [x] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] Title of the PR contains starts with chart name e.g. `[chart]`
