### PR TITLE
[mariadb-galera] Increase probe timeouts

### DIFF
--- a/appuio/mariadb-galera/Chart.yaml
+++ b/appuio/mariadb-galera/Chart.yaml
@@ -27,4 +27,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-mariadb-galera
   - https://github.com/prometheus/mysqld_exporter
   - https://mariadb.org
-version: 1.2.1
+version: 1.2.2

--- a/appuio/mariadb-galera/README.md
+++ b/appuio/mariadb-galera/README.md
@@ -1,6 +1,6 @@
 # mariadb-galera
 
-![Version: 1.2.1](https://img.shields.io/badge/Version-1.2.1-informational?style=flat-square) ![AppVersion: 10.5.12](https://img.shields.io/badge/AppVersion-10.5.12-informational?style=flat-square)
+![Version: 1.2.2](https://img.shields.io/badge/Version-1.2.2-informational?style=flat-square) ![AppVersion: 10.5.12](https://img.shields.io/badge/AppVersion-10.5.12-informational?style=flat-square)
 
 MariaDB Galera is a multi-master database cluster solution for synchronous replication and high availability.
 
@@ -80,7 +80,7 @@ Edit the README.gotmpl.md template instead.
 | livenessProbe.initialDelaySeconds | int | `120` |  |
 | livenessProbe.periodSeconds | int | `10` | How often to perform the probe |
 | livenessProbe.successThreshold | int | `1` | consecutive successes for the probe |
-| livenessProbe.timeoutSeconds | int | `1` | When the probe times out |
+| livenessProbe.timeoutSeconds | int | `5` | When the probe times out |
 | mariadbConfiguration | string | `"[client]\nport=3306\nsocket=/opt/bitnami/mariadb/tmp/mysql.sock\nplugin_dir=/opt/bitnami/mariadb/plugin\n\n[mysqld]\ndefault_storage_engine=InnoDB\nbasedir=/opt/bitnami/mariadb\ndatadir=/bitnami/mariadb/data\nplugin_dir=/opt/bitnami/mariadb/plugin\ntmpdir=/opt/bitnami/mariadb/tmp\nsocket=/opt/bitnami/mariadb/tmp/mysql.sock\npid_file=/opt/bitnami/mariadb/tmp/mysqld.pid\nbind_address=0.0.0.0\n\n## Character set\n##\ncollation_server=utf8_unicode_ci\ninit_connect='SET NAMES utf8'\ncharacter_set_server=utf8\n\n## MyISAM\n##\nkey_buffer_size=32M\nmyisam_recover_options=FORCE,BACKUP\n\n## Safety\n##\nskip_host_cache\nskip_name_resolve\nmax_allowed_packet=16M\nmax_connect_errors=1000000\nsql_mode=STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_AUTO_VALUE_ON_ZERO,NO_ENGINE_SUBSTITUTION,NO_ZERO_DATE,NO_ZERO_IN_DATE,ONLY_FULL_GROUP_BY\nsysdate_is_now=1\n\n## Binary Logging\n##\nlog_bin=mysql-bin\nexpire_logs_days=14\n# Disabling for performance per http://severalnines.com/blog/9-tips-going-production-galera-cluster-mysql\nsync_binlog=0\n# Required for Galera\nbinlog_format=row\n\n## Caches and Limits\n##\ntmp_table_size=32M\nmax_heap_table_size=32M\n# Re-enabling as now works with Maria 10.1.2\nquery_cache_type=1\nquery_cache_limit=4M\nquery_cache_size=256M\nmax_connections=500\nthread_cache_size=50\nopen_files_limit=65535\ntable_definition_cache=4096\ntable_open_cache=4096\n\n## InnoDB\n##\ninnodb=FORCE\ninnodb_strict_mode=1\n# Mandatory per https://github.com/codership/documentation/issues/25\ninnodb_autoinc_lock_mode=2\n# Per https://www.percona.com/blog/2006/08/04/innodb-double-write/\ninnodb_doublewrite=1\ninnodb_flush_method=O_DIRECT\ninnodb_log_files_in_group=2\ninnodb_log_file_size=128M\ninnodb_flush_log_at_trx_commit=1\ninnodb_file_per_table=1\n# 80% Memory is default reco.\n# Need to re-evaluate when DB size grows\ninnodb_buffer_pool_size=2G\ninnodb_file_format=Barracuda\n\n## Logging\n##\nlog_error=/opt/bitnami/mariadb/logs/mysqld.log\nslow_query_log_file=/opt/bitnami/mariadb/logs/mysqld.log\nlog_queries_not_using_indexes=1\nslow_query_log=1\n\n## SSL\n## Use extraVolumes and extraVolumeMounts to mount /certs filesystem\n# ssl_ca=/certs/ca.pem\n# ssl_cert=/certs/server-cert.pem\n# ssl_key=/certs/server-key.pem\n\n[galera]\nwsrep_on=ON\nwsrep_provider=/opt/bitnami/mariadb/lib/libgalera_smm.so\nwsrep_sst_method=mariabackup\nwsrep_slave_threads=4\nwsrep_cluster_address=gcomm://\nwsrep_cluster_name=galera\nwsrep_sst_auth=\"root:\"\n# Enabled for performance per https://mariadb.com/kb/en/innodb-system-variables/#innodb_flush_log_at_trx_commit\ninnodb_flush_log_at_trx_commit=2\n# MYISAM REPLICATION SUPPORT #\nwsrep_replicate_myisam=ON\n\n[mariadb]\nplugin_load_add=auth_pam\n\n## Data-at-Rest Encryption\n## Use extraVolumes and extraVolumeMounts to mount /encryption filesystem\n# plugin_load_add=file_key_management\n# file_key_management_filename=/encryption/keyfile.enc\n# file_key_management_filekey=FILE:/encryption/keyfile.key\n# file_key_management_encryption_algorithm=AES_CTR\n# encrypt_binlog=ON\n# encrypt_tmp_files=ON\n\n## InnoDB/XtraDB Encryption\n# innodb_encrypt_tables=ON\n# innodb_encrypt_temporary_tables=ON\n# innodb_encrypt_log=ON\n# innodb_encryption_threads=4\n# innodb_encryption_rotate_key_age=1\n\n## Aria Encryption\n# aria_encrypt_tables=ON\n# encrypt_tmp_disk_tables=ON"` | Configuration for the MariaDB server |
 | metrics.enabled | bool | `false` | Start a side-car prometheus exporter |
 | metrics.extraFlags | list | `[]` | MariaDB Prometheus exporter additional command line flags |
@@ -133,7 +133,7 @@ Edit the README.gotmpl.md template instead.
 | readinessProbe.initialDelaySeconds | int | `30` | Delay before readiness probe is initiated |
 | readinessProbe.periodSeconds | int | `10` | How often to perform the probe |
 | readinessProbe.successThreshold | int | `1` | Minimum consecutive successes for the probe |
-| readinessProbe.timeoutSeconds | int | `1` | When the probe times out |
+| readinessProbe.timeoutSeconds | int | `5` | When the probe times out |
 | replicaCount | int | `3` | Desired number of cluster nodes |
 | resources.limits | object | `{}` |  |
 | resources.requests | object | `{}` |  |
@@ -160,7 +160,7 @@ Edit the README.gotmpl.md template instead.
 | startupProbe.initialDelaySeconds | int | `120` |  |
 | startupProbe.periodSeconds | int | `10` | How often to perform the probe |
 | startupProbe.successThreshold | int | `1` | Minimum consecutive successes for the probe |
-| startupProbe.timeoutSeconds | int | `1` | When the probe times out |
+| startupProbe.timeoutSeconds | int | `5` | When the probe times out |
 | tls.autoGenerated | bool | `false` | Generate automatically self-signed TLS certificates |
 | tls.certCAFilename | string | `""` | CA Certificate filename |
 | tls.certFilename | string | `""` | Certificate filename |

--- a/appuio/mariadb-galera/values.yaml
+++ b/appuio/mariadb-galera/values.yaml
@@ -570,7 +570,7 @@ livenessProbe:
   # -- How often to perform the probe
   periodSeconds: 10
   # -- When the probe times out
-  timeoutSeconds: 1
+  timeoutSeconds: 5
   # -- consecutive successes for the probe
   successThreshold: 1
   # -- Minimum consecutive failures for the probe
@@ -586,7 +586,7 @@ readinessProbe:
   # -- How often to perform the probe
   periodSeconds: 10
   # -- When the probe times out
-  timeoutSeconds: 1
+  timeoutSeconds: 5
   # -- Minimum consecutive successes for the probe
   successThreshold: 1
   # -- Minimum consecutive failures for the probe
@@ -603,7 +603,7 @@ startupProbe:
   # -- How often to perform the probe
   periodSeconds: 10
   # -- When the probe times out
-  timeoutSeconds: 1
+  timeoutSeconds: 5
   # -- Minimum consecutive successes for the probe
   successThreshold: 1
   ## Let's wait 600 seconds by default, it should give enough time in any cluster for mysql to init


### PR DESCRIPTION
With Kubernetes v1.20 a bug was fixed where exec probe timeouts were not
respected. This fix led to failing probes for Redis because the timeout
of 1s is actually too short.

<!--
Thank you for contributing to appuio/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

-->

#### What this PR does / why we need it:

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] I have run `make docs`
- [x] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] Title of the PR contains starts with chart name e.g. `[chart]`
