### PR TITLE
[stardog] Deduplicated license expiry alerts

### DIFF
--- a/appuio/stardog/Chart.yaml
+++ b/appuio/stardog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: stardog
-version: 0.8.0
+version: 0.8.1
 appVersion: 7.7.2
 description: Stardog is the world’s leading knowledge graph platform for the enterprise. Stardog makes it fast and easy to turn enterprise data into knowledge.
 home: "https://www.stardog.com/"

--- a/appuio/stardog/README.md
+++ b/appuio/stardog/README.md
@@ -1,6 +1,6 @@
 # stardog
 
-![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![AppVersion: 7.7.2](https://img.shields.io/badge/AppVersion-7.7.2-informational?style=flat-square)
+![Version: 0.8.1](https://img.shields.io/badge/Version-0.8.1-informational?style=flat-square) ![AppVersion: 7.7.2](https://img.shields.io/badge/AppVersion-7.7.2-informational?style=flat-square)
 
 Stardog is the world’s leading knowledge graph platform for the enterprise. Stardog makes it fast and easy to turn enterprise data into knowledge.
 

--- a/appuio/stardog/templates/monitoring/stardog-rules.yaml
+++ b/appuio/stardog/templates/monitoring/stardog-rules.yaml
@@ -25,7 +25,7 @@ spec:
         app: stardog
         severity: critical
     - alert: StardogLicenseExpire
-      expr: dbms_license_expiration{ {{ $ns_selector }} } < 42
+      expr: "min(dbms_license_expiration{ {{ $ns_selector }} ) without (instance, pod) < 42"
       for: 10m
       annotations:
         summary: Stardog license about to expire


### PR DESCRIPTION
#### What this PR does / why we need it:

* Alerts may refire when a pod is restarted, causing duplicated alerts

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] Chart Version bumped
- [x] I have run `make docs`
- [x] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] PR contains the label that identifies the chart, e.g. `chart/<chart-name>`
- [x] PR contains the label that identifies the type of change, which is one of
      [ `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency` ]
