### PR TITLE
[stardog] Upgrade Stardog to 7.8.1

### DIFF
--- a/appuio/stardog/Chart.yaml
+++ b/appuio/stardog/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: stardog
-version: 0.8.1
-appVersion: 7.7.2
+version: 0.8.2
+appVersion: 7.8.1
 description: Stardog is the world’s leading knowledge graph platform for the enterprise. Stardog makes it fast and easy to turn enterprise data into knowledge.
 home: "https://www.stardog.com/"
 icon: https://d33wubrfki0l68.cloudfront.net/img/c920235ff153186ab17617ce2bce193d867fa80c/stardog-logo.png

--- a/appuio/stardog/README.md
+++ b/appuio/stardog/README.md
@@ -1,6 +1,6 @@
 # stardog
 
-![Version: 0.8.1](https://img.shields.io/badge/Version-0.8.1-informational?style=flat-square) ![AppVersion: 7.7.2](https://img.shields.io/badge/AppVersion-7.7.2-informational?style=flat-square)
+![Version: 0.8.2](https://img.shields.io/badge/Version-0.8.2-informational?style=flat-square) ![AppVersion: 7.8.1](https://img.shields.io/badge/AppVersion-7.8.1-informational?style=flat-square)
 
 Stardog is the world’s leading knowledge graph platform for the enterprise. Stardog makes it fast and easy to turn enterprise data into knowledge.
 

--- a/appuio/stardog/templates/monitoring/stardog-rules.yaml
+++ b/appuio/stardog/templates/monitoring/stardog-rules.yaml
@@ -25,7 +25,7 @@ spec:
         app: stardog
         severity: critical
     - alert: StardogLicenseExpire
-      expr: "min(dbms_license_expiration{ {{ $ns_selector }} ) without (instance, pod) < 42"
+      expr: min(dbms_license_expiration{ {{ $ns_selector }} } without (instance, pod) < 42
       for: 10m
       annotations:
         summary: Stardog license about to expire

--- a/appuio/stardog/values.yaml
+++ b/appuio/stardog/values.yaml
@@ -11,7 +11,7 @@ image:
   registry: stardog-eps-docker.jfrog.io
   # username:
   # password:
-  tag: 7.7.2
+  tag: 7.8.1
   pullPolicy: IfNotPresent
   # existingPullSecret: my-image-pull-secret
 


### PR DESCRIPTION
#### What this PR does / why we need it:

* This upgrades Stardog to upstream version 7.8.1 which addresses CVE-2021-44228 ([release notes](https://docs.stardog.com/release-notes/stardog-platform#781-release-2021-12-10))
* Fixes a YAML syntax error in the monitoring rules introduced in #377

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] Chart Version bumped
- [x] I have run `make docs`
- [x] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] PR contains the label that identifies the chart, e.g. `chart/<chart-name>`
- [x] PR contains the label that identifies the type of change, which is one of
      [ `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency` ]
