### PR TITLE
[haproxy][redis] Shutdown connections after failed check

### DIFF
--- a/appuio/haproxy/Chart.yaml
+++ b/appuio/haproxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 2.3.5
 description: A Helm chart for HAProxy which can be customized by a config map.
 name: haproxy
-version: 1.4.1
+version: 1.5.0
 maintainers:
   - name: APPUiO Team
     email: info@appuio.ch

--- a/appuio/haproxy/README.md
+++ b/appuio/haproxy/README.md
@@ -1,6 +1,6 @@
 # haproxy
 
-![Version: 1.4.1](https://img.shields.io/badge/Version-1.4.1-informational?style=flat-square) ![AppVersion: 2.3.5](https://img.shields.io/badge/AppVersion-2.3.5-informational?style=flat-square)
+![Version: 1.5.0](https://img.shields.io/badge/Version-1.5.0-informational?style=flat-square) ![AppVersion: 2.3.5](https://img.shields.io/badge/AppVersion-2.3.5-informational?style=flat-square)
 
 A Helm chart for HAProxy which can be customized by a config map.
 

--- a/appuio/haproxy/templates/configmap-redisk8s.yaml
+++ b/appuio/haproxy/templates/configmap-redisk8s.yaml
@@ -56,5 +56,5 @@ data:
       tcp-check expect string +OK
       {{- end }}
 
-      server-template redis- {{ $redisk8s.nodeCount }} {{ $redisk8s.dnsservicename }}:{{ default "6379" $redisk8s.port }} {{ if $redisk8s.check.enabled }}check inter 1s {{ end }}resolvers mydns init-addr none
+      server-template redis- {{ $redisk8s.nodeCount }} {{ $redisk8s.dnsservicename }}:{{ default "6379" $redisk8s.port }} {{ if $redisk8s.check.enabled }}check inter 1s on-marked-down shutdown-sessions {{ end }}resolvers mydns init-addr none
 {{- end }}


### PR DESCRIPTION
<!--
Thank you for contributing to appuio/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

-->

#### What this PR does / why we need it:

After a failover, checks will fail for the former leader node.

Without shutting down open connections after such an event, applications
can, depending on their client-library implementation, get stuck with open
connections to the former leader, which is now a read-only follower.
This in turn leads to read-only errors for write operations, as long as
the application does not initiate a re-connect.

We should not rely on client-libraries initiating re-connects for such
events when we abstract the Sentinel away with HAProxy.

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] Chart Version bumped
- [x] I have run `make docs`
- [x] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] PR contains the label that identifies the chart, e.g. `chart/<chart-name>`
- [x] PR contains the label that identifies the type of change, which is one of
      [ `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency` ]
