### PR TITLE
New configuration syntax for Secrets

### DIFF
--- a/appuio/secret/.helmignore
+++ b/appuio/secret/.helmignore
@@ -19,3 +19,7 @@
 .project
 .idea/
 *.tmproj
+
+Makefile
+*gotmpl*
+test/

--- a/appuio/secret/Chart.yaml
+++ b/appuio/secret/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: Deploy arbitrary secrets
 type: application
 name: secret
-version: 2.0.0
+version: 1.1.0
 maintainers:
   - name: APPUiO Team
     email: info@appuio.ch

--- a/appuio/secret/Chart.yaml
+++ b/appuio/secret/Chart.yaml
@@ -1,7 +1,8 @@
-apiVersion: v1
+apiVersion: v2
 description: Deploy arbitrary secrets
+type: application
 name: secret
-version: 1.0.2
+version: 2.0.0
 maintainers:
   - name: APPUiO Team
     email: info@appuio.ch

--- a/appuio/secret/README.gotmpl.md
+++ b/appuio/secret/README.gotmpl.md
@@ -5,3 +5,26 @@ Edit the README.gotmpl.md template instead.
 -->
 
 {{ template "chart.valuesSection" . }}
+
+## Upgrade chart v1 to v2
+
+Type of `.Values.secrets` changed from List to Dict to better support deep-merging behaviour of hierarchical configuration management tools.
+Each key of `.secrets` is now the default `metadata.name` of a secret.
+
+To upgrade, take the value of `.secrets[*].name` and make it a key.
+Given the example below, restructure the `name` and rename `values` to `stringData`:
+```yaml
+secrets:
+- name: db-creds
+  values:
+    db-host: mysql
+```
+to
+```yaml
+secrets:
+  db-creds:
+    stringData:
+      db-host: mysql
+```
+The additional fields `.type` and `.labels` also need to be moved beneath the new name key (given example: `db-creds`).
+v2 also now supports additional fields, see the example in `values.yaml`.

--- a/appuio/secret/README.gotmpl.md
+++ b/appuio/secret/README.gotmpl.md
@@ -4,6 +4,9 @@ The README.md file is automatically generated with helm-docs!
 Edit the README.gotmpl.md template instead.
 -->
 
+Note: Properties suffixed with `Templates` support template functions and variables.
+All standard Helm functions are available (https://helm.sh/docs/chart_template_guide/function_list/).
+
 {{ template "chart.valuesSection" . }}
 
 ## Upgrade chart v1 to v2

--- a/appuio/secret/README.gotmpl.md
+++ b/appuio/secret/README.gotmpl.md
@@ -9,12 +9,16 @@ All standard Helm functions are available (https://helm.sh/docs/chart_template_g
 
 {{ template "chart.valuesSection" . }}
 
-## Upgrade chart v1 to v2
+## Upgrade configuration syntax
 
-Type of `.Values.secrets` changed from List to Dict to better support deep-merging behaviour of hierarchical configuration management tools.
-Each key of `.secrets` is now the default `metadata.name` of a secret.
+From version `1.1.0` onwards, the type of `secrets` changed from array to object to better support deep-merging behaviour of hierarchical configuration management tools.
+Specifying `secrets` as an array is deprecated.
+The changes are backwards compatible, altough you will note some default label changes.
 
-To upgrade, take the value of `.secrets[*].name` and make it a key.
+Going forward, `secrets` is now an object by default.
+Each key of `secrets` is the `metadata.name` of a secret.
+
+To upgrade to the new structure, take the value of `secrets[*].name` and make it a key.
 Given the example below, restructure the `name` and rename `values` to `stringData`:
 ```yaml
 secrets:
@@ -30,4 +34,4 @@ secrets:
       db-host: mysql
 ```
 The additional fields `.type` and `.labels` also need to be moved beneath the new name key (given example: `db-creds`).
-v2 also now supports additional fields, see the example in `values.yaml`.
+v1.2 also now supports additional fields, see the example in `values.yaml`.

--- a/appuio/secret/README.md
+++ b/appuio/secret/README.md
@@ -16,6 +16,9 @@ The README.md file is automatically generated with helm-docs!
 Edit the README.gotmpl.md template instead.
 -->
 
+Note: Properties suffixed with `Templates` support template functions and variables.
+All standard Helm functions are available (https://helm.sh/docs/chart_template_guide/function_list/).
+
 ## Values
 
 | Key | Type | Default | Description |

--- a/appuio/secret/README.md
+++ b/appuio/secret/README.md
@@ -20,7 +20,7 @@ Edit the README.gotmpl.md template instead.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| secrets | object | `{}` | Dict with key/values. Each key is the name of the secret. Each value may contain an object with `.name`, `.type`, `.stringData`, `.data`, `.labels`, `.annotations`. If `.name` is not given, the key name is used. See an example in `values.yaml`. |
+| secrets | object | `{}` | Dict with key/values. Each key is the name of the secret. Each value may contain an object with `.name`, `.type`, `.stringData`, `.data`, `.labels`, `.annotations`. If `.name` is not given, the key name is used. You can pass additional templated stringData using `.stringDataTemplates`. See an example in `values.yaml`. |
 
 <!---
 Common/Useful Link references from values.yaml

--- a/appuio/secret/README.md
+++ b/appuio/secret/README.md
@@ -22,6 +22,29 @@ Edit the README.gotmpl.md template instead.
 |-----|------|---------|-------------|
 | secrets | object | `{}` | Dict with key/values. Each key is the name of the secret. Each value may contain an object with `.name`, `.type`, `.stringData`, `.data`, `.labels`, `.annotations`. If `.name` is not given, the key name is used. You can pass additional templated stringData using `.stringDataTemplates`. See an example in `values.yaml`. |
 
+## Upgrade chart v1 to v2
+
+Type of `.Values.secrets` changed from List to Dict to better support deep-merging behaviour of hierarchical configuration management tools.
+Each key of `.secrets` is now the default `metadata.name` of a secret.
+
+To upgrade, take the value of `.secrets[*].name` and make it a key.
+Given the example below, restructure the `name` and rename `values` to `stringData`:
+```yaml
+secrets:
+- name: db-creds
+  values:
+    db-host: mysql
+```
+to
+```yaml
+secrets:
+  db-creds:
+    stringData:
+      db-host: mysql
+```
+The additional fields `.type` and `.labels` also need to be moved beneath the new name key (given example: `db-creds`).
+v2 also now supports additional fields, see the example in `values.yaml`.
+
 <!---
 Common/Useful Link references from values.yaml
 -->

--- a/appuio/secret/README.md
+++ b/appuio/secret/README.md
@@ -1,6 +1,6 @@
 # secret
 
-![Version: 2.0.0](https://img.shields.io/badge/Version-2.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Deploy arbitrary secrets
 
@@ -25,12 +25,16 @@ All standard Helm functions are available (https://helm.sh/docs/chart_template_g
 |-----|------|---------|-------------|
 | secrets | object | `{}` | Dict with key/values. Each key is the name of the secret. Each value may contain an object with `.nameTemplate`, `.type`, `.stringData`, `.data`, `.labels`, `.annotations`. If `.nameTemplate` is not given, the key name is used. You can pass additional templates to `.stringDataTemplates` and `.nameTemplate`. See an example in `values.yaml`. |
 
-## Upgrade chart v1 to v2
+## Upgrade configuration syntax
 
-Type of `.Values.secrets` changed from List to Dict to better support deep-merging behaviour of hierarchical configuration management tools.
-Each key of `.secrets` is now the default `metadata.name` of a secret.
+From version `1.1.0` onwards, the type of `secrets` changed from array to object to better support deep-merging behaviour of hierarchical configuration management tools.
+Specifying `secrets` as an array is deprecated.
+The changes are backwards compatible, altough you will note some default label changes.
 
-To upgrade, take the value of `.secrets[*].name` and make it a key.
+Going forward, `secrets` is now an object by default.
+Each key of `secrets` is the `metadata.name` of a secret.
+
+To upgrade to the new structure, take the value of `secrets[*].name` and make it a key.
 Given the example below, restructure the `name` and rename `values` to `stringData`:
 ```yaml
 secrets:
@@ -46,7 +50,7 @@ secrets:
       db-host: mysql
 ```
 The additional fields `.type` and `.labels` also need to be moved beneath the new name key (given example: `db-creds`).
-v2 also now supports additional fields, see the example in `values.yaml`.
+v1.2 also now supports additional fields, see the example in `values.yaml`.
 
 <!---
 Common/Useful Link references from values.yaml

--- a/appuio/secret/README.md
+++ b/appuio/secret/README.md
@@ -1,6 +1,6 @@
 # secret
 
-![Version: 1.0.2](https://img.shields.io/badge/Version-1.0.2-informational?style=flat-square)
+![Version: 2.0.0](https://img.shields.io/badge/Version-2.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Deploy arbitrary secrets
 
@@ -20,7 +20,7 @@ Edit the README.gotmpl.md template instead.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| secrets | list | `[]` |  |
+| secrets | object | `{}` | Dict with key/values. Each key is the name of the secret. Each value may contain an object with `.name`, `.type`, `.stringData`, `.data`, `.labels`, `.annotations`. If `.name` is not given, the key name is used. See an example in `values.yaml`. |
 
 <!---
 Common/Useful Link references from values.yaml

--- a/appuio/secret/README.md
+++ b/appuio/secret/README.md
@@ -20,7 +20,7 @@ Edit the README.gotmpl.md template instead.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| secrets | object | `{}` | Dict with key/values. Each key is the name of the secret. Each value may contain an object with `.name`, `.type`, `.stringData`, `.data`, `.labels`, `.annotations`. If `.name` is not given, the key name is used. You can pass additional templated stringData using `.stringDataTemplates`. See an example in `values.yaml`. |
+| secrets | object | `{}` | Dict with key/values. Each key is the name of the secret. Each value may contain an object with `.nameTemplate`, `.type`, `.stringData`, `.data`, `.labels`, `.annotations`. If `.nameTemplate` is not given, the key name is used. You can pass additional templates to `.stringDataTemplates` and `.nameTemplate`. See an example in `values.yaml`. |
 
 ## Upgrade chart v1 to v2
 

--- a/appuio/secret/templates/NOTES.txt
+++ b/appuio/secret/templates/NOTES.txt
@@ -1,0 +1,6 @@
+{{- if kindIs "slice" .Values.secrets }}
+*** Warning ***
+You have configured the parameter `secrets` using arrays, which is deprecated.
+Please change `secrets` to a key-value object.
+See more details in the chart README.
+{{- end -}}

--- a/appuio/secret/templates/_helpers.tpl
+++ b/appuio/secret/templates/_helpers.tpl
@@ -1,10 +1,9 @@
-{{/* vim: set filetype=mustache: */}}
 {{/*
 Expand the name of the chart.
 */}}
 {{- define "secret.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
 
 {{/*
 Create a default fully qualified app name.
@@ -12,21 +11,34 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 If release name contains chart name it will be used as a full name.
 */}}
 {{- define "secret.fullname" -}}
-{{- if .Values.fullnameOverride -}}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
-{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-{{- end -}}
-{{- end -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
 
 {{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "secret.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "secret.labels" -}}
+helm.sh/chart: {{ include "secret.chart" . }}
+app.kubernetes.io/name: {{ include "secret.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}

--- a/appuio/secret/templates/secret-deprecated.yaml
+++ b/appuio/secret/templates/secret-deprecated.yaml
@@ -1,0 +1,17 @@
+{{- if kindIs "slice" .Values.secrets }}
+{{- range .Values.secrets }}
+---
+apiVersion: v1
+kind: Secret
+type: {{ default "Opaque" .type }}
+metadata:
+  name: {{ .name }}
+  labels:
+    {{- include "secret.labels" $ | nindent 4 }}
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+stringData:
+  {{- toYaml .values | nindent 2 -}}
+{{- end -}}
+{{- end -}}

--- a/appuio/secret/templates/secret.yaml
+++ b/appuio/secret/templates/secret.yaml
@@ -1,15 +1,10 @@
+{{- if kindIs "map" .Values.secrets }}
 {{- range $name, $value := .Values.secrets }}
 ---
-{{- with $value }}
 apiVersion: v1
 kind: Secret
 type: {{ default "Opaque" .type }}
 metadata:
-  {{- if .nameTemplate }}
-  name: {{ tpl .nameTemplate $ }}
-  {{- else }}
-  name: {{ $name }}
-  {{- end }}
   labels:
     {{- include "secret.labels" $ | nindent 4 }}
     {{- with .labels }}
@@ -18,6 +13,11 @@ metadata:
   {{- with .annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- if .nameTemplate }}
+  name: {{ tpl .nameTemplate $ }}
+  {{- else }}
+  name: {{ $name }}
   {{- end }}
 {{- if .stringData }}
 stringData:

--- a/appuio/secret/templates/secret.yaml
+++ b/appuio/secret/templates/secret.yaml
@@ -5,7 +5,11 @@ apiVersion: v1
 kind: Secret
 type: {{ default "Opaque" .type }}
 metadata:
-  name: {{ default $name .name }}
+  {{- if .nameTemplate }}
+  name: {{ tpl .nameTemplate $ }}
+  {{- else }}
+  name: {{ $name }}
+  {{- end }}
   labels:
     {{- include "secret.labels" $ | nindent 4 }}
     {{- with .labels }}

--- a/appuio/secret/templates/secret.yaml
+++ b/appuio/secret/templates/secret.yaml
@@ -1,16 +1,27 @@
-{{- range .Values.secrets }}
+{{- range $name, $value := .Values.secrets }}
 ---
+{{- with $value }}
 apiVersion: v1
 kind: Secret
 type: {{ default "Opaque" .type }}
 metadata:
-  name: {{ .name }}
+  name: {{ default $name .name }}
   labels:
-    app: {{ template "secret.name" $ }}
-    chart: {{ template "secret.chart" $ }}
-    release: {{ $.Release.Name }}
-    heritage: {{ $.Release.Service }}
-{{ with .labels -}}{{- toYaml . | indent 4 -}}{{- end }}
+    {{- include "secret.labels" $ | nindent 4 }}
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- if .stringData }}
 stringData:
-{{ toYaml .values | indent 2 -}}
+  {{- toYaml .stringData | nindent 2 -}}
+{{- end }}
+{{- if .data }}
+data:
+  {{- toYaml .data | nindent 2 -}}
+{{- end }}
+{{- end -}}
 {{- end -}}

--- a/appuio/secret/templates/secret.yaml
+++ b/appuio/secret/templates/secret.yaml
@@ -18,10 +18,13 @@ metadata:
 {{- if .stringData }}
 stringData:
   {{- toYaml .stringData | nindent 2 -}}
+  {{- range $key, $template := .stringDataTemplates }}
+  {{ $key }}: {{ tpl $template $ | toYaml  | indent 2 }}
+  {{- end }}
 {{- end }}
 {{- if .data }}
 data:
-  {{- toYaml .data | nindent 2 -}}
+  {{- toYaml .data | nindent 2 }}
 {{- end }}
 {{- end -}}
 {{- end -}}

--- a/appuio/secret/test/main_test.go
+++ b/appuio/secret/test/main_test.go
@@ -1,0 +1,6 @@
+package test
+
+var (
+	helmChartPath = ".."
+	releaseName   = "test-release"
+)

--- a/appuio/secret/test/secret_array_test.go
+++ b/appuio/secret/test/secret_array_test.go
@@ -1,0 +1,26 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/helm"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+)
+
+var tplSecretDeprecated = []string{"templates/secret-deprecated.yaml"}
+
+func TestSecret_ArraySyntax(t *testing.T) {
+	options := &helm.Options{
+		ValuesFiles: []string{"testdata/secret-array.yaml"},
+	}
+
+	output := helm.RenderTemplate(t, options, helmChartPath, releaseName, tplSecretDeprecated)
+
+	secret := corev1.Secret{}
+	helm.UnmarshalK8SYaml(t, output, &secret)
+
+	assert.Equal(t, "foo-secret", secret.Name)
+	assert.Equal(t, "database", secret.Labels["app"])
+	assert.Equal(t, "file", secret.StringData["static"])
+}

--- a/appuio/secret/test/secret_object_test.go
+++ b/appuio/secret/test/secret_object_test.go
@@ -1,0 +1,32 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/helm"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+)
+
+var tplSecret = []string{"templates/secret.yaml"}
+
+func TestSecret_ObjectSyntax(t *testing.T) {
+	options := &helm.Options{
+		ValuesFiles: []string{"testdata/secret-object.yaml"},
+		SetValues: map[string]string{
+			"external": "foo",
+		},
+	}
+
+	output := helm.RenderTemplate(t, options, helmChartPath, releaseName, tplSecret)
+
+	secret := corev1.Secret{}
+	helm.UnmarshalK8SYaml(t, output, &secret)
+
+	assert.Equal(t, "foo-secret", secret.Name)
+	assert.Equal(t, "database", secret.Labels["app"])
+	assert.Equal(t, "github", secret.Annotations["app.kubernetes.io/source"])
+	assert.Equal(t, "file", secret.StringData["static"])
+	assert.Equal(t, "App", secret.StringData["dynamic"])
+	assert.NotNil(t, secret.Data["base64"])
+}

--- a/appuio/secret/test/testdata/secret-array.yaml
+++ b/appuio/secret/test/testdata/secret-array.yaml
@@ -1,0 +1,6 @@
+secrets:
+  - name: foo-secret
+    labels:
+      app: database
+    values:
+      static: file

--- a/appuio/secret/test/testdata/secret-object.yaml
+++ b/appuio/secret/test/testdata/secret-object.yaml
@@ -1,0 +1,13 @@
+secrets:
+  app:
+    labels:
+      app: database
+    annotations:
+      app.kubernetes.io/source: "github"
+    nameTemplate: '{{ .Values.external }}-secret'
+    stringData:
+      static: file
+    stringDataTemplates:
+      dynamic: '{{ title "app" }}'
+    data:
+      base64: aGVsbG8=

--- a/appuio/secret/values.yaml
+++ b/appuio/secret/values.yaml
@@ -1,13 +1,13 @@
 ---
 # -- Dict with key/values. Each key is the name of the secret.
-# Each value may contain an object with `.name`, `.type`, `.stringData`, `.data`, `.labels`, `.annotations`.
-# If `.name` is not given, the key name is used.
-# You can pass additional templated stringData using `.stringDataTemplates`.
+# Each value may contain an object with `.nameTemplate`, `.type`, `.stringData`, `.data`, `.labels`, `.annotations`.
+# If `.nameTemplate` is not given, the key name is used.
+# You can pass additional templates to `.stringDataTemplates` and `.nameTemplate`.
 # See an example in `values.yaml`.
 secrets: {}
 # secrets:
 #   my-secret-name:
-#     name: overridden-name # optional
+#     nameTemplate: '{{ .Values.fullnameOverride | default .Release.Name }}-suffix' # optional
 #     stringData:
 #       my-user: example
 #       my-file: |

--- a/appuio/secret/values.yaml
+++ b/appuio/secret/values.yaml
@@ -2,6 +2,7 @@
 # -- Dict with key/values. Each key is the name of the secret.
 # Each value may contain an object with `.name`, `.type`, `.stringData`, `.data`, `.labels`, `.annotations`.
 # If `.name` is not given, the key name is used.
+# You can pass additional templated stringData using `.stringDataTemplates`.
 # See an example in `values.yaml`.
 secrets: {}
 # secrets:
@@ -12,6 +13,10 @@ secrets: {}
 #       my-file: |
 #         [section]
 #         config = value
+#     stringDataTemplates:
+#       my-template: |
+#         date={{ now }}
+#       my-name: '{{ .Values.secrets.database.name }}'
 #     data:
 #       my-key: some-base64-encoded-string
 #     labels: # optional

--- a/appuio/secret/values.yaml
+++ b/appuio/secret/values.yaml
@@ -1,10 +1,20 @@
 ---
-secrets: []
-  # - name: db-creds
-  #   type: Opaque
-  #   values:
-  #     db-host: mysql
-  #     db-user: mysql
-  #     db-pass: verysekr1t!
-  #   labels:
-  #     app: mah-app
+# -- Dict with key/values. Each key is the name of the secret.
+# Each value may contain an object with `.name`, `.type`, `.stringData`, `.data`, `.labels`, `.annotations`.
+# If `.name` is not given, the key name is used.
+# See an example in `values.yaml`.
+secrets: {}
+# secrets:
+#   my-secret-name:
+#     name: overridden-name # optional
+#     stringData:
+#       my-user: example
+#       my-file: |
+#         [section]
+#         config = value
+#     data:
+#       my-key: some-base64-encoded-string
+#     labels: # optional
+#       app: database
+#     annotations: # optional
+#       my-annotation: a string value


### PR DESCRIPTION
#### What this PR does / why we need it:

* Updates the generic `Secret` chart with a new value usage with additional fields.
* Added upgrade documentation
* Now also supports templated strings via `stringDataTemplates`
* Supports new value syntax (example):
```yaml
secrets:
  database: # this is the secret name
    nameTemplate: '{{ .Release.Name }}-suffix' # this allows referencing secret names from other charts
    stringData:
      my-user: example
      my-file: |
        [section]
        config = value
    data:
      my-key: some-base64-encoded-string
    labels:
      app: database
    annotations:
      my-annotation: a string value
    stringDataTemplates:
      my-template: |
        date={{ now }}
      my-name: '{{ .Values.secrets.database.name }}'
```

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] Chart Version bumped
- [x] I have run `make docs`
- [x] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] PR contains the label that identifies the chart, e.g. `chart/<chart-name>`
- [x] PR contains the label that identifies the type of change, which is one of
      [ `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency` ]
