### PR TITLE
Allow configuring environment variables

### DIFF
--- a/appuio/cloud-portal/Chart.yaml
+++ b/appuio/cloud-portal/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.0
 
 # Update this value by running `make prepare` as it takes it from values.yaml.
 appVersion: v0.0.1

--- a/appuio/cloud-portal/README.md
+++ b/appuio/cloud-portal/README.md
@@ -1,6 +1,6 @@
 # cloud-portal
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.0.1](https://img.shields.io/badge/AppVersion-v0.0.1-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.0.1](https://img.shields.io/badge/AppVersion-v0.0.1-informational?style=flat-square)
 
 APPUiO Cloud Portal (Web Frontend)
 
@@ -38,6 +38,7 @@ Edit the README.gotmpl.md template instead.
 | podAnnotations | object | `{}` | Annotations to add to the Pod spec. |
 | podSecurityContext | object | `{}` | Security context to add to the Pod spec. |
 | portal.config | object | `{}` | Arbitrary (nested) keys and values that are put as JSON into `config.json` as a static frontend asset. Don't put secret values here, as this file is publicly accessible. |
+| portal.env | object | `{}` | Arbitrary {key:string} values that are used to configure additional environment variables. They are meant to configure NGINX config files (envsubst) |
 | replicaCount | int | `1` |  |
 | resources.limits.memory | string | `"128Mi"` |  |
 | resources.requests.cpu | string | `"20m"` |  |

--- a/appuio/cloud-portal/templates/configmap.yaml
+++ b/appuio/cloud-portal/templates/configmap.yaml
@@ -1,9 +1,21 @@
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "cloud-portal.fullname" . }}
+  name: {{ include "cloud-portal.fullname" . }}-frontend
   labels:
     {{- include "cloud-portal.labels" . | nindent 4 }}
 data:
   config.json: |
     {{- toJson .Values.portal.config | nindent 4 }}
+{{- if .Values.portal.env }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "cloud-portal.fullname" . }}-env
+  labels:
+    {{- include "cloud-portal.labels" . | nindent 4 }}
+data:
+  {{- toYaml .Values.portal.env | nindent 2 }}
+{{- end -}}

--- a/appuio/cloud-portal/templates/deployment.yaml
+++ b/appuio/cloud-portal/templates/deployment.yaml
@@ -48,12 +48,17 @@ spec:
             - name: config
               mountPath: /usr/share/nginx/html/config.json
               subPath: config.json
+          {{- if .Values.portal.env }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "cloud-portal.fullname" . }}-env
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:
         - name: config
           configMap:
-            name: {{ include "cloud-portal.fullname" . }}
+            name: {{ include "cloud-portal.fullname" . }}-frontend
             items:
               - key: config.json
                 path: config.json

--- a/appuio/cloud-portal/values.yaml
+++ b/appuio/cloud-portal/values.yaml
@@ -25,6 +25,12 @@ portal:
   # Don't put secret values here, as this file is publicly accessible.
   config: {}
 
+  # -- Arbitrary {key:string} values that are used to configure additional environment variables.
+  # They are meant to configure NGINX config files (envsubst)
+  env: {}
+  # example:
+  # SOME_KEY: VALUE
+
 serviceAccount:
   # -- Specifies whether a service account should be created
   create: true


### PR DESCRIPTION

#### What this PR does / why we need it:
* Allows configuring env vars using `portal.env` key, which accepts key-values
* Required for https://github.com/appuio/cloud-portal/pull/53

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] Chart Version bumped
- [x] I have run `make docs`
- [x] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] PR contains the label that identifies the chart, e.g. `chart/<chart-name>`
- [x] PR contains the label that identifies the type of change, which is one of
      [ `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency` ]
