### PR TITLE
[stardog] Make ZooKeeper session timeout configurable

### DIFF
--- a/appuio/stardog/Chart.yaml
+++ b/appuio/stardog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: stardog
-version: 0.8.2
+version: 0.9.0
 appVersion: 7.8.1
 description: Stardog is the world’s leading knowledge graph platform for the enterprise. Stardog makes it fast and easy to turn enterprise data into knowledge.
 home: "https://www.stardog.com/"

--- a/appuio/stardog/README.gotmpl.md
+++ b/appuio/stardog/README.gotmpl.md
@@ -61,5 +61,5 @@ The following table lists the configurable parameters chart. For default values 
 | `zookeeper.auth.enabled`                     | Enable ZooKeeper authentication |
 | `zookeeper.auth.clientPassword`              | Password to use for ZooKeeper clients. Will be generated if unset |
 | `zookeeper.auth.serverPasswords`             | Password to use for ZooKeeper servers (delimited by `,`). Will be generated if unset |
-| `zookeeper.metrics.enabled`                  | Enable ZooKeeper Proemtheus exporter |
-| `zookeeper.metrics.prometheusOperator`       | Enable Proemtheus Operator integration (requires the operator to be installed) |
+| `zookeeper.metrics.enabled`                  | Enable ZooKeeper Prometheus exporter |
+| `zookeeper.metrics.prometheusOperator`       | Enable Prometheus Operator integration (requires the operator to be installed) |

--- a/appuio/stardog/README.gotmpl.md
+++ b/appuio/stardog/README.gotmpl.md
@@ -63,3 +63,5 @@ The following table lists the configurable parameters chart. For default values 
 | `zookeeper.auth.serverPasswords`             | Password to use for ZooKeeper servers (delimited by `,`). Will be generated if unset |
 | `zookeeper.metrics.enabled`                  | Enable ZooKeeper Prometheus exporter |
 | `zookeeper.metrics.prometheusOperator`       | Enable Prometheus Operator integration (requires the operator to be installed) |
+| `zookeeper.sessionTimeout`                   | Set the ZooKeeper [session timeout](https://docs.stardog.com/cluster/installation-and-setup/#connectionsession-timeouts) |
+

--- a/appuio/stardog/README.md
+++ b/appuio/stardog/README.md
@@ -75,8 +75,9 @@ The following table lists the configurable parameters chart. For default values 
 | `zookeeper.auth.enabled`                     | Enable ZooKeeper authentication |
 | `zookeeper.auth.clientPassword`              | Password to use for ZooKeeper clients. Will be generated if unset |
 | `zookeeper.auth.serverPasswords`             | Password to use for ZooKeeper servers (delimited by `,`). Will be generated if unset |
-| `zookeeper.metrics.enabled`                  | Enable ZooKeeper Proemtheus exporter |
-| `zookeeper.metrics.prometheusOperator`       | Enable Proemtheus Operator integration (requires the operator to be installed) |
+| `zookeeper.metrics.enabled`                  | Enable ZooKeeper Prometheus exporter |
+| `zookeeper.metrics.prometheusOperator`       | Enable Prometheus Operator integration (requires the operator to be installed) |
+| `zookeeper.sessionTimeout`       | Set the ZooKeeper [session timeout](https://docs.stardog.com/cluster/installation-and-setup/#connectionsession-timeouts) |
 
 ## Requirements
 

--- a/appuio/stardog/README.md
+++ b/appuio/stardog/README.md
@@ -1,6 +1,6 @@
 # stardog
 
-![Version: 0.8.2](https://img.shields.io/badge/Version-0.8.2-informational?style=flat-square) ![AppVersion: 7.8.1](https://img.shields.io/badge/AppVersion-7.8.1-informational?style=flat-square)
+![Version: 0.9.0](https://img.shields.io/badge/Version-0.9.0-informational?style=flat-square) ![AppVersion: 7.8.1](https://img.shields.io/badge/AppVersion-7.8.1-informational?style=flat-square)
 
 Stardog is the world’s leading knowledge graph platform for the enterprise. Stardog makes it fast and easy to turn enterprise data into knowledge.
 
@@ -77,7 +77,7 @@ The following table lists the configurable parameters chart. For default values 
 | `zookeeper.auth.serverPasswords`             | Password to use for ZooKeeper servers (delimited by `,`). Will be generated if unset |
 | `zookeeper.metrics.enabled`                  | Enable ZooKeeper Prometheus exporter |
 | `zookeeper.metrics.prometheusOperator`       | Enable Prometheus Operator integration (requires the operator to be installed) |
-| `zookeeper.sessionTimeout`       | Set the ZooKeeper [session timeout](https://docs.stardog.com/cluster/installation-and-setup/#connectionsession-timeouts) |
+| `zookeeper.sessionTimeout`                   | Set the ZooKeeper [session timeout](https://docs.stardog.com/cluster/installation-and-setup/#connectionsession-timeouts) |
 
 ## Requirements
 

--- a/appuio/stardog/templates/configmap.yaml
+++ b/appuio/stardog/templates/configmap.yaml
@@ -17,7 +17,7 @@ data:
     {{- if .Values.zookeeper.enabled -}}
     pack.enabled=true
     pack.zookeeper.address={{ template "stardog.zookeeperConnection" . }}
-    pack.session.timeout=15s
+    pack.session.timeout={{ .Values.zookeeper.sessionTimeout }}
     pack.curator.retry.count=42
     pack.node.join.retry.count=42
     {{- if .Values.zookeeper.auth.enabled }}

--- a/appuio/stardog/values.yaml
+++ b/appuio/stardog/values.yaml
@@ -106,6 +106,7 @@ zookeeper:
   replicaCount: 3
   updateStrategy: OnDelete
   allowAnonymousLogin: false
+  sessionTimeout: 15s
   auth:
     enabled: true
     clientUser: stardogClient


### PR DESCRIPTION
#### What this PR does / why we need it:

* The ZooKeeper session timeout was previously hardcoded in values.yaml but should be configurable. A higher timeout may be required when a Stardog cluster is under load.

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] Chart Version bumped
- [x] I have run `make docs`
- [x] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] PR contains the label that identifies the chart, e.g. `chart/<chart-name>`
- [x] PR contains the label that identifies the type of change, which is one of
      [ `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency` ]
