### PR TITLE
Add additional parameter to control if metrics port should be exposed

### DIFF
--- a/appuio/haproxy/Chart.yaml
+++ b/appuio/haproxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 2.5.1
 description: A Helm chart for HAProxy which can be customized by a config map.
 name: haproxy
-version: 1.6.0
+version: 1.6.1
 maintainers:
   - name: APPUiO Team
     email: info@appuio.ch

--- a/appuio/haproxy/README.md
+++ b/appuio/haproxy/README.md
@@ -1,6 +1,6 @@
 # haproxy
 
-![Version: 1.6.0](https://img.shields.io/badge/Version-1.6.0-informational?style=flat-square) ![AppVersion: 2.5.1](https://img.shields.io/badge/AppVersion-2.5.1-informational?style=flat-square)
+![Version: 1.6.1](https://img.shields.io/badge/Version-1.6.1-informational?style=flat-square) ![AppVersion: 2.5.1](https://img.shields.io/badge/AppVersion-2.5.1-informational?style=flat-square)
 
 A Helm chart for HAProxy which can be customized by a config map.
 

--- a/appuio/haproxy/templates/service.yaml
+++ b/appuio/haproxy/templates/service.yaml
@@ -14,7 +14,7 @@ spec:
       targetPort: {{ .Values.haproxy.frontendPort }}
       protocol: TCP
       name: frontend
-    {{- if or .Values.haproxy.redisk8s.metrics.enabled .Values.haproxy.galerak8s.metrics.enabled}}
+    {{- if and (or .Values.haproxy.redisk8s.metrics.exposeLoadbalancer .VAlues.haproxy.galerak8s.metrics.exposeLoadbalancer) (or .Values.haproxy.redisk8s.metrics.enabled .Values.haproxy.galerak8s.metrics.enabled})}
     - port: 9090
       targetPort: metrics-backend
       protocol: TCP

--- a/appuio/haproxy/values.yaml
+++ b/appuio/haproxy/values.yaml
@@ -85,6 +85,8 @@ haproxy:
     nodeCount: 3
     metrics:
       enabled: false
+      exposeLoadbalancer: true
+
 
   redisk8s:
     timeout:
@@ -100,6 +102,7 @@ haproxy:
     nodeCount: 3
     metrics:
       enabled: false
+      exposeLoadbalancer: true
 
 metrics:
   enabled: true


### PR DESCRIPTION
The port is exposed via dedicated service and not via the main haproxy
service.

<!--
Thank you for contributing to appuio/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

-->

#### What this PR does / why we need it:

* Short summary

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] Chart Version bumped
- [x] I have run `make docs`
- [x] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] PR contains the label that identifies the chart, e.g. `chart/<chart-name>`
- [x] PR contains the label that identifies the type of change, which is one of
      [ `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency` ]
