### PR TITLE
Overhaul metrics exposure for redis and mariadb

### DIFF
--- a/appuio/haproxy/Chart.yaml
+++ b/appuio/haproxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 2.5.1
 description: A Helm chart for HAProxy which can be customized by a config map.
 name: haproxy
-version: 1.6.1
+version: 1.7.0
 maintainers:
   - name: APPUiO Team
     email: info@appuio.ch

--- a/appuio/haproxy/README.gotmpl.md
+++ b/appuio/haproxy/README.gotmpl.md
@@ -115,6 +115,7 @@ Set `haproxy.config` to `galerak8s` to use the Galera configuration with DNS ser
 | `haproxy.galerak8s.nodeCount` | Max number of nodes in the backend | `3`
 | `haproxy.galerak8s.port` | Port of the Galera node | `3306`
 | `haproxy.galerak8s.metrics.enabled`| If the metric endpoint of the Galera backends should be exposed in haproxy | `false`
+| `haproxy.galerak8s.metrics.exposeLoadbalancer`| If the metric endpoint of the Galera backends should be exposed in the haproxy service | `true`
 
 ### redisk8s
 
@@ -131,6 +132,7 @@ Set `haproxy.config` to `redisk8s` to use the Redis configuration with DNS servi
 | `haproxy.redisk8s.nodeCount` | Max number of nodes in the backend | `3`
 | `haproxy.redisk8s.port` | Port of the Galera node | `6379`
 | `haproxy.redisk8s.metrics.enabled`| If the metric endpoint of the Redis backends should be exposed in haproxy | `false`
+| `haproxy.redisk8s.metrics.exposeLoadbalancer`| If the metric endpoint of the Redis backends should be exposed in the haproxy service | `true`
 
 
 ## Galera and Redis metrics

--- a/appuio/haproxy/README.gotmpl.md
+++ b/appuio/haproxy/README.gotmpl.md
@@ -93,6 +93,8 @@ Set `haproxy.config` to `galera` to use the Galera configuration.
 | `haproxy.galera.nodes.address` | Address of the Galera node |
 | `haproxy.galera.nodes.port` | Port of the Galera node | `3306`
 | `haproxy.galera.nodes.backup` | If this node should be used as a backup node | `true`
+| `haproxy.galera.metrics.enabled`| If the metric endpoint of the Galera backends should be exposed in haproxy | `false`
+| `haproxy.galera.metrics.exposeLoadbalancer`| If the metric endpoint of the Galera backends should be exposed in the haproxy service | `true`
 
 To use `mysql-check`, configure a user `haproxy` in the database (see: http://cbonte.github.io/haproxy-dconv/1.9/configuration.html#4-option%20mysql-check for more information).
 

--- a/appuio/haproxy/README.md
+++ b/appuio/haproxy/README.md
@@ -1,6 +1,6 @@
 # haproxy
 
-![Version: 1.6.1](https://img.shields.io/badge/Version-1.6.1-informational?style=flat-square) ![AppVersion: 2.5.1](https://img.shields.io/badge/AppVersion-2.5.1-informational?style=flat-square)
+![Version: 1.7.0](https://img.shields.io/badge/Version-1.7.0-informational?style=flat-square) ![AppVersion: 2.5.1](https://img.shields.io/badge/AppVersion-2.5.1-informational?style=flat-square)
 
 A Helm chart for HAProxy which can be customized by a config map.
 

--- a/appuio/haproxy/README.md
+++ b/appuio/haproxy/README.md
@@ -103,6 +103,8 @@ Set `haproxy.config` to `galera` to use the Galera configuration.
 | `haproxy.galera.nodes.address` | Address of the Galera node |
 | `haproxy.galera.nodes.port` | Port of the Galera node | `3306`
 | `haproxy.galera.nodes.backup` | If this node should be used as a backup node | `true`
+| `haproxy.galera.metrics.enabled`| If the metric endpoint of the Galera backends should be exposed in haproxy | `false`
+| `haproxy.galera.metrics.exposeLoadbalancer`| If the metric endpoint of the Galera backends should be exposed in the haproxy service | `true`
 
 To use `mysql-check`, configure a user `haproxy` in the database (see: http://cbonte.github.io/haproxy-dconv/1.9/configuration.html#4-option%20mysql-check for more information).
 

--- a/appuio/haproxy/templates/_helpers.tpl
+++ b/appuio/haproxy/templates/_helpers.tpl
@@ -93,15 +93,15 @@ HAProxy config for galerak8s metrics
 frontend galeraMetrics
   mode http
   bind *:9090
+  option httplog
   {{- range $i, $e := until (.Values.haproxy.galerak8s.nodeCount |int) }}
-  use_backend galera-node-{{$i}} if { path -i -m beg /metrics/mariadb-{{$i}} }
+  use_backend galera-node-{{$i}} if { hdr_sub(host) -i mariadb-{{$i}} }
   {{- end }}
 
 {{ range $i, $e := until (.Values.haproxy.galerak8s.nodeCount |int) }}
 backend galera-node-{{$i}}
   mode http
   server node-{{$i}} mariadb-{{$i}}.mariadb:9104
-  http-request set-path '%[path,regsub(^/metrics/mariadb-{{$i}}/,/)]'
 {{- end }}
 {{- end }}
 {{- end -}}
@@ -114,15 +114,15 @@ HAProxy config for redis metrics
 frontend redisMetrics
   mode http
   bind *:9090
+  option httplog
   {{- range $i, $e := until (.Values.haproxy.redisk8s.nodeCount |int) }}
-  use_backend redis-node-{{$i}} if { path -i -m beg /metrics/redis-{{$i}} }
+  use_backend redis-node-{{$i}} if { hdr_sub(host) -i redis-{{$i}} }
   {{- end }}
 
 {{ range $i, $e := until (.Values.haproxy.redisk8s.nodeCount |int) }}
 backend redis-node-{{$i}}
   mode http
   server node-{{$i}} redis-node-{{$i}}.redis-headless:9121
-  http-request set-path '%[path,regsub(^/metrics/redis-{{$i}}/,/)]'
 {{- end }}
 {{- end }}
 {{- end -}}

--- a/appuio/haproxy/templates/_helpers.tpl
+++ b/appuio/haproxy/templates/_helpers.tpl
@@ -68,6 +68,27 @@ resolvers mydns
 HAProxy config for galera metrics
 */}}
 {{- define "haproxy.galeraMetricsConfig" -}}
+{{- if .Values.haproxy.galera.metrics.enabled }}
+frontend galeraMetrics
+  mode http
+  bind *:9090
+  option httplog
+  {{- range $i, $node := .Values.haproxy.galera.nodes }}
+  use_backend galera-node-{{$i}} if { hdr_sub(host) -i mariadb-{{$i}} }
+  {{- end }}
+
+{{- range $i, $node := .Values.haproxy.galera.nodes }}
+backend galera-node-{{$i}}
+  mode http
+  server node-{{$i}} {{ $node.address }}:9104
+{{- end }}
+{{- end }}
+{{- end -}}
+
+{{/*
+HAProxy config for galerak8s metrics
+*/}}
+{{- define "haproxy.galerak8sMetricsConfig" -}}
 {{- if .Values.haproxy.galerak8s.metrics.enabled }}
 frontend galeraMetrics
   mode http

--- a/appuio/haproxy/templates/configmap-galera.yaml
+++ b/appuio/haproxy/templates/configmap-galera.yaml
@@ -32,6 +32,8 @@ data:
       option clitcpka
       default_backend galera-nodes
 
+    {{- include "haproxy.galerak8sMetricsConfig" . | nindent 4 }}
+    
     backend galera-nodes
       mode tcp
       option srvtcpka

--- a/appuio/haproxy/templates/configmap-galerak8s.yaml
+++ b/appuio/haproxy/templates/configmap-galerak8s.yaml
@@ -32,7 +32,7 @@ data:
       option clitcpka
       default_backend galera-nodes
 
-    {{- include "haproxy.galeraMetricsConfig" . | nindent 4 }}
+    {{- include "haproxy.galerak8sMetricsConfig" . | nindent 4 }}
 
     backend galera-nodes
       mode tcp

--- a/appuio/haproxy/templates/service.yaml
+++ b/appuio/haproxy/templates/service.yaml
@@ -14,7 +14,7 @@ spec:
       targetPort: {{ .Values.haproxy.frontendPort }}
       protocol: TCP
       name: frontend
-    {{- if and (or .Values.haproxy.redisk8s.metrics.exposeLoadbalancer .VAlues.haproxy.galerak8s.metrics.exposeLoadbalancer) (or .Values.haproxy.redisk8s.metrics.enabled .Values.haproxy.galerak8s.metrics.enabled})}
+    {{- if and (or .Values.haproxy.redisk8s.metrics.exposeLoadbalancer .Values.haproxy.galerak8s.metrics.exposeLoadbalancer .Values.haproxy.galera.metrics.exposeLoadbalancer) (or .Values.haproxy.redisk8s.metrics.enabled .Values.haproxy.galerak8s.metrics.enabled .Values.haproxy.galera.metrics.enabled})}
     - port: 9090
       targetPort: metrics-backend
       protocol: TCP

--- a/appuio/haproxy/values.yaml
+++ b/appuio/haproxy/values.yaml
@@ -68,6 +68,9 @@ haproxy:
     # - address: galera-node-1
     #   port: 3306
     #   backup: false
+    metrics:
+      enabled: false
+      exposeLoadbalancer: true
 
   galerak8s:
     balance: first # see http://cbonte.github.io/haproxy-dconv/1.9/configuration.html#4-balance
@@ -86,7 +89,6 @@ haproxy:
     metrics:
       enabled: false
       exposeLoadbalancer: true
-
 
   redisk8s:
     timeout:


### PR DESCRIPTION
Signed-off-by: Nicolas Bigler <nicolas.bigler@vshn.ch>

<!--
Thank you for contributing to appuio/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

-->

#### What this PR does / why we need it:

* Added metrics support for the `galera` haproxy config
* Change endpoint format:
Instead of exposing the individual pods via the `path` of the url, we
will use the `Host` header and use a subdomains for route to the correct
pod.

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] Chart Version bumped
- [x] I have run `make docs`
- [x] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] PR contains the label that identifies the chart, e.g. `chart/<chart-name>`
- [x] PR contains the label that identifies the type of change, which is one of
      [ `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency` ]
