### PR TITLE
Generate list of charts and download counter in the README

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Generate Chart documentation
-        run: make docs -e go_cmd=go
+        run: make docs
       - name: Check if documentation is on par with Chart changes
         run: git diff --exit-code
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Generate Chart documentation
-        run: make docs
+        run: make docs -e go_cmd=go
       - name: Check if documentation is on par with Chart changes
         run: git diff --exit-code
 

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,11 @@ CHARTS_DIR=appuio
 
 HELM_DOCS_VERSION=v1.7.0
 
-go_cmd ?= docker run --rm -v $$(pwd):/go/src -u $$(id -u):$$(id -g) -w /go/src bitnami/golang go
+go_cmd := $(shell command -v go 2> /dev/null)
+
+ifndef go_cmd
+    go_cmd := docker run --rm -v $$(pwd):/go/src -u $$(id -u):$$(id -g) -w /go/src bitnami/golang go
+endif
 
 .PHONY: help
 help: ## Show this help

--- a/Makefile
+++ b/Makefile
@@ -13,12 +13,14 @@ CHARTS_DIR=appuio
 
 HELM_DOCS_VERSION=v1.7.0
 
+go_cmd ?= docker run --rm -v $$(pwd):/go/src -u $$(id -u):$$(id -g) -w /go/src bitnami/golang go
+
 .PHONY: help
 help: ## Show this help
 	@grep -E -h '\s##\s' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = "(: ).*?## "}; {gsub(/\\:/,":",$$1)}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
 
 .PHONY: docs
-docs: docs\:helm
+docs: docs\:helm docs\:readme
 
 .PHONY: docs\:helm
 docs\:helm: ## Creates the Chart READMEs from template and values.yaml files
@@ -27,6 +29,10 @@ docs\:helm: ## Creates the Chart READMEs from template and values.yaml files
 		--template-files ./.github/helm-docs-header.gotmpl.md \
 		--template-files README.gotmpl.md \
 		--template-files ./.github/helm-docs-footer.gotmpl.md
+
+.PHONY: docs\:readme
+docs\:readme: ## Creates the root README from template
+	@$(go_cmd) run readme.go $(SOURCE_README) $(TARGET_README) $(CHARTS_DIR)/
 
 .PHONY: test
 test: ## Run Chart unit tests

--- a/README.gotmpl
+++ b/README.gotmpl
@@ -1,0 +1,47 @@
+# Helm Charts for APPUiO
+
+[![License](https://img.shields.io/github/license/appuio/charts)](https://github.com/appuio/charts/blob/master/LICENSE)
+[![Downloads](https://img.shields.io/github/downloads/appuio/charts/total)](https://github.com/appuio/charts/releases)
+
+## Usage
+
+Add the repo:
+
+```
+helm repo add appuio https://charts.appuio.ch
+```
+
+## List of Charts
+
+| Downloads & Changelog | Chart |
+| --- | --- |
+{{- range .charts }}
+| {{ if .version }}[![chart downloads](https://img.shields.io/github/downloads/appuio/charts/{{ .name }}-{{ .version }}/total)](https://github.com/appuio/charts/releases/tag/{{ .name }}-{{ .version }}){{ end }} | [{{ .name }}]({{ .dir }}{{ .name }}/README.md) |
+{{- end }}
+
+## Add / Update Charts
+
+New charts and versions will be built and published automatically as GitHub Releases. All charts use the Semantic Versioning release strategy.
+
+Each PR shall be labelled with the chart name using the pattern `chart/<chart-name>`. The labels help building a changelog when releaseing a new chart version. Please request a new label if the label is missing for a new chart.
+
+The following GitHub pull request labels require certain SemVer version increments:
+
+| Label | SemVer increment | Usage examples |
+| --- | --- | --- |
+| `bug` | Patch | Fix an unintended behaviour |
+| `change` | Patch | Reimplementation of existing features, code improvements |
+| `change` | Minor | Deprecate an existing feature |
+| `dependency` | Patch | Patches or minor updates from a dependency that causes no known significant change |
+| `dependency` | Major | Dependency update that causes breaking changes for the users |
+| `enhancement` | Minor | New features |
+| `breaking` | Major | See below |
+
+### Breaking changes
+
+Pull request authors and reviewers are obliged to correctly identify breaking changes.
+The following changes are examples of breaking changes:
+
+* Changes of existing parameters in default configuration (new optional or default parameters should’t be breaking).
+* Changes that require manual upgrade steps when upgrading the chart version (can also be caused by dependency updates).
+* Removal of existing behaviour or features.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,30 @@ Add the repo:
 helm repo add appuio https://charts.appuio.ch
 ```
 
+## List of Charts
+
+| Downloads & Changelog | Chart |
+| --- | --- |
+| [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/cloud-portal-0.4.0/total)](https://github.com/appuio/charts/releases/tag/cloud-portal-0.4.0) | [cloud-portal](appuio/cloud-portal/README.md) |
+| [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/data-cube-curation-0.3.1/total)](https://github.com/appuio/charts/releases/tag/data-cube-curation-0.3.1) | [data-cube-curation](appuio/data-cube-curation/README.md) |
+| [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/exoip-1.0.4/total)](https://github.com/appuio/charts/releases/tag/exoip-1.0.4) | [exoip](appuio/exoip/README.md) |
+| [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/generic-0.1.2/total)](https://github.com/appuio/charts/releases/tag/generic-0.1.2) | [generic](appuio/generic/README.md) |
+| [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/haproxy-1.7.5/total)](https://github.com/appuio/charts/releases/tag/haproxy-1.7.5) | [haproxy](appuio/haproxy/README.md) |
+| [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/k8up-2.0.2/total)](https://github.com/appuio/charts/releases/tag/k8up-2.0.2) | [k8up](appuio/k8up/README.md) |
+| [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/mariadb-galera-1.2.3/total)](https://github.com/appuio/charts/releases/tag/mariadb-galera-1.2.3) | [mariadb-galera](appuio/mariadb-galera/README.md) |
+| [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/maxscale-1.1.2/total)](https://github.com/appuio/charts/releases/tag/maxscale-1.1.2) | [maxscale](appuio/maxscale/README.md) |
+| [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/metrics-server-2.12.1/total)](https://github.com/appuio/charts/releases/tag/metrics-server-2.12.1) | [metrics-server](appuio/metrics-server/README.md) |
+| [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/openshift-oauth-proxy-0.2.3/total)](https://github.com/appuio/charts/releases/tag/openshift-oauth-proxy-0.2.3) | [openshift-oauth-proxy](appuio/openshift-oauth-proxy/README.md) |
+| [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/openshift-route-1.1.4/total)](https://github.com/appuio/charts/releases/tag/openshift-route-1.1.4) | [openshift-route](appuio/openshift-route/README.md) |
+| [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/prometheus-blackbox-exporter-0.3.1/total)](https://github.com/appuio/charts/releases/tag/prometheus-blackbox-exporter-0.3.1) | [prometheus-blackbox-exporter](appuio/prometheus-blackbox-exporter/README.md) |
+| [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/redis-1.3.4/total)](https://github.com/appuio/charts/releases/tag/redis-1.3.4) | [redis](appuio/redis/README.md) |
+| [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/secret-1.1.0/total)](https://github.com/appuio/charts/releases/tag/secret-1.1.0) | [secret](appuio/secret/README.md) |
+| [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/signalilo-0.7.0/total)](https://github.com/appuio/charts/releases/tag/signalilo-0.7.0) | [signalilo](appuio/signalilo/README.md) |
+| [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/snappass-0.2.14/total)](https://github.com/appuio/charts/releases/tag/snappass-0.2.14) | [snappass](appuio/snappass/README.md) |
+| [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/stardog-0.10.0/total)](https://github.com/appuio/charts/releases/tag/stardog-0.10.0) | [stardog](appuio/stardog/README.md) |
+| [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/stardog-userrole-operator-0.1.0/total)](https://github.com/appuio/charts/releases/tag/stardog-userrole-operator-0.1.0) | [stardog-userrole-operator](appuio/stardog-userrole-operator/README.md) |
+| [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/trifid-1.2.1/total)](https://github.com/appuio/charts/releases/tag/trifid-1.2.1) | [trifid](appuio/trifid/README.md) |
+
 ## Add / Update Charts
 
 New charts and versions will be built and published automatically as GitHub Releases. All charts use the Semantic Versioning release strategy.

--- a/readme.go
+++ b/readme.go
@@ -1,0 +1,65 @@
+//go:build readme
+// +build readme
+
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/template"
+)
+
+func main() {
+	// Get Template filename
+	t, err := template.ParseFiles(os.Args[1])
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	// Get Target filename
+	f, err := os.Create(os.Args[2])
+	defer f.Close()
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	chartsDir := os.Args[3]
+
+	files, _ := filepath.Glob("**/*/Chart.yaml")
+	var charts []map[string]string
+	for _, file := range files {
+		charts = append(charts, map[string]string{
+			"name":    strings.Split(file, "/")[1],
+			"dir":     chartsDir,
+			"version": extractVersion(file),
+		})
+	}
+	err = t.Execute(f, map[string]interface{}{
+		"charts":       charts,
+	})
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+}
+
+func extractVersion(filepath string) string {
+	f, err := os.Open(filepath)
+	if err != nil {
+		fmt.Println(err)
+		return ""
+	}
+	defer f.Close()
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "version: ") {
+			version := strings.TrimPrefix(line, "version: ")
+			return version
+		}
+	}
+	return ""
+}


### PR DESCRIPTION


#### What this PR does / why we need it:

* Adds another make target in the `make docs` that generates a Markdown table in the README.
* The table contains a badge with a download counter for the corresponding version, and a link to the README.

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] I have run `make docs`
- [x] PR contains the label that identifies the type of change, which is one of
      [ `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency` ]
