### PR TITLE
Add correct backend check for the metrics backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ helm repo add appuio https://charts.appuio.ch
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/data-cube-curation-0.3.1/total)](https://github.com/appuio/charts/releases/tag/data-cube-curation-0.3.1) | [data-cube-curation](appuio/data-cube-curation/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/exoip-1.0.4/total)](https://github.com/appuio/charts/releases/tag/exoip-1.0.4) | [exoip](appuio/exoip/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/generic-0.1.2/total)](https://github.com/appuio/charts/releases/tag/generic-0.1.2) | [generic](appuio/generic/README.md) |
-| [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/haproxy-1.7.6/total)](https://github.com/appuio/charts/releases/tag/haproxy-1.7.6) | [haproxy](appuio/haproxy/README.md) |
+| [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/haproxy-1.7.7/total)](https://github.com/appuio/charts/releases/tag/haproxy-1.7.7) | [haproxy](appuio/haproxy/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/k8up-2.0.3/total)](https://github.com/appuio/charts/releases/tag/k8up-2.0.3) | [k8up](appuio/k8up/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/mariadb-galera-1.2.3/total)](https://github.com/appuio/charts/releases/tag/mariadb-galera-1.2.3) | [mariadb-galera](appuio/mariadb-galera/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/maxscale-1.1.2/total)](https://github.com/appuio/charts/releases/tag/maxscale-1.1.2) | [maxscale](appuio/maxscale/README.md) |

--- a/appuio/haproxy/Chart.yaml
+++ b/appuio/haproxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 2.5.1
 description: A Helm chart for HAProxy which can be customized by a config map.
 name: haproxy
-version: 1.7.6
+version: 1.7.7
 maintainers:
   - name: APPUiO Team
     email: info@appuio.ch

--- a/appuio/haproxy/README.md
+++ b/appuio/haproxy/README.md
@@ -1,6 +1,6 @@
 # haproxy
 
-![Version: 1.7.6](https://img.shields.io/badge/Version-1.7.6-informational?style=flat-square) ![AppVersion: 2.5.1](https://img.shields.io/badge/AppVersion-2.5.1-informational?style=flat-square)
+![Version: 1.7.7](https://img.shields.io/badge/Version-1.7.7-informational?style=flat-square) ![AppVersion: 2.5.1](https://img.shields.io/badge/AppVersion-2.5.1-informational?style=flat-square)
 
 A Helm chart for HAProxy which can be customized by a config map.
 

--- a/appuio/haproxy/templates/_helpers.tpl
+++ b/appuio/haproxy/templates/_helpers.tpl
@@ -80,7 +80,7 @@ frontend galeraMetrics
 {{- range $i, $node := .Values.haproxy.galera.nodes }}
 backend galera-node-{{$i}}
   mode http
-  server node-{{$i}} {{ $node.address }}:9104 check
+  server node-{{$i}} {{ $node.address }}:9104 init-addr none check resolvers mydns
 {{- end }}
 {{- end }}
 {{- end -}}
@@ -101,7 +101,7 @@ frontend galeraMetrics
 {{ range $i, $e := until (.Values.haproxy.galerak8s.nodeCount |int) }}
 backend galera-node-{{$i}}
   mode http
-  server node-{{$i}} mariadb-{{$i}}.mariadb:9104 check
+  server node-{{$i}} mariadb-{{$i}}.mariadb:9104 init-addr none check resolvers mydns
 {{- end }}
 {{- end }}
 {{- end -}}
@@ -122,7 +122,7 @@ frontend redisMetrics
 {{ range $i, $e := until (.Values.haproxy.redisk8s.nodeCount |int) }}
 backend redis-node-{{$i}}
   mode http
-  server node-{{$i}} redis-node-{{$i}}.redis-headless:9121 check
+  server node-{{$i}} redis-node-{{$i}}.redis-headless:9121 init-addr none check resolvers mydns
 {{- end }}
 {{- end }}
 {{- end -}}


### PR DESCRIPTION
<!--
Thank you for contributing to appuio/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

-->

#### What this PR does / why we need it:

Without the `init-addr none` option, haproxy will not start up if the
backend doesn't exist yet (i.e is not resolvable yet, because the pod
doesn't exist yet).
Furthermore setting sane hold times for the resolver ensures, that when
a backend pod is restarted, that haproxy will get the new IP address as
soon as possible.

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] Chart Version bumped
- [x] I have run `make docs`
- [ ] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] PR contains the label that identifies the chart, e.g. `chart/<chart-name>`
- [x] PR contains the label that identifies the type of change, which is one of
      [ `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency` ]
