### PR TITLE
Configure autopurge for ZooKeeper

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ helm repo add appuio https://charts.appuio.ch
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/secret-1.1.0/total)](https://github.com/appuio/charts/releases/tag/secret-1.1.0) | [secret](appuio/secret/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/signalilo-0.7.0/total)](https://github.com/appuio/charts/releases/tag/signalilo-0.7.0) | [signalilo](appuio/signalilo/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/snappass-0.2.14/total)](https://github.com/appuio/charts/releases/tag/snappass-0.2.14) | [snappass](appuio/snappass/README.md) |
-| [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/stardog-0.10.0/total)](https://github.com/appuio/charts/releases/tag/stardog-0.10.0) | [stardog](appuio/stardog/README.md) |
+| [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/stardog-0.11.0/total)](https://github.com/appuio/charts/releases/tag/stardog-0.11.0) | [stardog](appuio/stardog/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/stardog-userrole-operator-0.1.0/total)](https://github.com/appuio/charts/releases/tag/stardog-userrole-operator-0.1.0) | [stardog-userrole-operator](appuio/stardog-userrole-operator/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/trifid-1.2.1/total)](https://github.com/appuio/charts/releases/tag/trifid-1.2.1) | [trifid](appuio/trifid/README.md) |
 

--- a/appuio/stardog/Chart.yaml
+++ b/appuio/stardog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: stardog
-version: 0.10.0
+version: 0.11.0
 appVersion: 7.9.0
 description: Stardog is the world’s leading knowledge graph platform for the enterprise. Stardog makes it fast and easy to turn enterprise data into knowledge.
 home: "https://www.stardog.com/"

--- a/appuio/stardog/README.gotmpl.md
+++ b/appuio/stardog/README.gotmpl.md
@@ -64,4 +64,5 @@ The following table lists the configurable parameters chart. For default values 
 | `zookeeper.metrics.enabled`                  | Enable ZooKeeper Prometheus exporter |
 | `zookeeper.metrics.prometheusOperator`       | Enable Prometheus Operator integration (requires the operator to be installed) |
 | `zookeeper.sessionTimeout`                   | Set the ZooKeeper [session timeout](https://docs.stardog.com/cluster/installation-and-setup/#connectionsession-timeouts) |
-
+| `zookeeper.autopurge.snapRetainCount`        | How many snapshots ZooKeeper should keep when [autopurging](https://zookeeper.apache.org/doc/r3.4.5/zookeeperAdmin.html#sc_strengthsAndLimitations) |
+| `zookeeper.autopurge.purgeInterval`        | Interval (in hours) for ZooKeeper autopurge |

--- a/appuio/stardog/README.md
+++ b/appuio/stardog/README.md
@@ -1,6 +1,6 @@
 # stardog
 
-![Version: 0.10.0](https://img.shields.io/badge/Version-0.10.0-informational?style=flat-square) ![AppVersion: 7.9.0](https://img.shields.io/badge/AppVersion-7.9.0-informational?style=flat-square)
+![Version: 0.11.0](https://img.shields.io/badge/Version-0.11.0-informational?style=flat-square) ![AppVersion: 7.9.0](https://img.shields.io/badge/AppVersion-7.9.0-informational?style=flat-square)
 
 Stardog is the world’s leading knowledge graph platform for the enterprise. Stardog makes it fast and easy to turn enterprise data into knowledge.
 

--- a/appuio/stardog/README.md
+++ b/appuio/stardog/README.md
@@ -78,6 +78,8 @@ The following table lists the configurable parameters chart. For default values 
 | `zookeeper.metrics.enabled`                  | Enable ZooKeeper Prometheus exporter |
 | `zookeeper.metrics.prometheusOperator`       | Enable Prometheus Operator integration (requires the operator to be installed) |
 | `zookeeper.sessionTimeout`                   | Set the ZooKeeper [session timeout](https://docs.stardog.com/cluster/installation-and-setup/#connectionsession-timeouts) |
+| `zookeeper.autopurge.snapRetainCount`        | How many snapshots ZooKeeper should keep when [autopurging](https://zookeeper.apache.org/doc/r3.4.5/zookeeperAdmin.html#sc_strengthsAndLimitations) |
+| `zookeeper.autopurge.purgeInterval`        | Interval (in hours) for ZooKeeper autopurge |
 
 ## Requirements
 

--- a/appuio/stardog/values.yaml
+++ b/appuio/stardog/values.yaml
@@ -107,6 +107,9 @@ zookeeper:
   updateStrategy: OnDelete
   allowAnonymousLogin: false
   sessionTimeout: 15s
+  autopurge: # Without autopurge, the PV will run full
+    snapRetainCount: 3
+    purgeInterval: 6 # In hours
   auth:
     enabled: true
     clientUser: stardogClient

--- a/appuio/stardog/values.yaml
+++ b/appuio/stardog/values.yaml
@@ -108,7 +108,6 @@ zookeeper:
   allowAnonymousLogin: false
   sessionTimeout: 15s
   autopurge: # Without autopurge, the PV will run full
-    snapRetainCount: 3
     purgeInterval: 6 # In hours
   auth:
     enabled: true


### PR DESCRIPTION
#### What this PR does / why we need it:

* Allow configuring ZooKeeper's `autopurge.snapRetainCount` and `autopurge.purgeInterval` options

If this option is not set, ZooKeeper will keep writing new snapshots indefinitely until its PV runs full.

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] Chart Version bumped
- [x] I have run `make docs`
- [x] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] PR contains the label that identifies the chart, e.g. `chart/<chart-name>`
- [x] PR contains the label that identifies the type of change, which is one of
      [ `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency` ]
