### PR TITLE
[appcat-service-postgresql] Add appcat service postgresql chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ helm repo add appuio https://charts.appuio.ch
 
 | Downloads & Changelog | Chart |
 | --- | --- |
+| [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/appcat-service-postgresql-0.1.0/total)](https://github.com/appuio/charts/releases/tag/appcat-service-postgresql-0.1.0) | [appcat-service-postgresql](appuio/appcat-service-postgresql/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/cloud-portal-0.4.1/total)](https://github.com/appuio/charts/releases/tag/cloud-portal-0.4.1) | [cloud-portal](appuio/cloud-portal/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/data-cube-curation-0.3.1/total)](https://github.com/appuio/charts/releases/tag/data-cube-curation-0.3.1) | [data-cube-curation](appuio/data-cube-curation/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/exoip-1.0.4/total)](https://github.com/appuio/charts/releases/tag/exoip-1.0.4) | [exoip](appuio/exoip/README.md) |

--- a/appuio/appcat-service-postgresql/.helmignore
+++ b/appuio/appcat-service-postgresql/.helmignore
@@ -1,0 +1,25 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+samples/
+Makefile

--- a/appuio/appcat-service-postgresql/Chart.yaml
+++ b/appuio/appcat-service-postgresql/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: provider-postgresql
+description: VSHN-opinionated PostgreSQL operator for AppCat
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+#appVersion: "master"

--- a/appuio/appcat-service-postgresql/README.gotmpl.md
+++ b/appuio/appcat-service-postgresql/README.gotmpl.md
@@ -1,0 +1,24 @@
+```bash
+kubectl apply -f https://github.com/vshn/appcat-service-postgresql/releases/download/provider-postgresql-{{ template "chart.version" . }}/crds.yaml
+```
+
+<!---
+The README.md file is automatically generated with helm-docs!
+
+Edit the README.gotmpl.md template instead.
+-->
+
+## Handling CRDs
+
+* Always upgrade the CRDs before upgrading the Helm release.
+* Watch out for breaking changes in the {{ title .Name }} release notes.
+
+{{ template "chart.sourcesSection" . }}
+
+{{ template "chart.requirementsSection" . }}
+<!---
+The values below are generated with helm-docs!
+
+Document your changes in values.yaml and let `make chart-docs` generate this section.
+-->
+{{ template "chart.valuesSection" . }}

--- a/appuio/appcat-service-postgresql/README.md
+++ b/appuio/appcat-service-postgresql/README.md
@@ -1,0 +1,66 @@
+# provider-postgresql
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+
+VSHN-opinionated PostgreSQL operator for AppCat
+
+## Installation
+
+```bash
+helm repo add appuio https://charts.appuio.ch
+helm install provider-postgresql appuio/provider-postgresql
+```
+```bash
+kubectl apply -f https://github.com/vshn/appcat-service-postgresql/releases/download/provider-postgresql-0.1.0/crds.yaml
+```
+
+<!---
+The README.md file is automatically generated with helm-docs!
+
+Edit the README.gotmpl.md template instead.
+-->
+
+## Handling CRDs
+
+* Always upgrade the CRDs before upgrading the Helm release.
+* Watch out for breaking changes in the Provider-Postgresql release notes.
+
+<!---
+The values below are generated with helm-docs!
+
+Document your changes in values.yaml and let `make chart-docs` generate this section.
+-->
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` |  |
+| fullnameOverride | string | `""` |  |
+| image.pullPolicy | string | `"IfNotPresent"` | Operator image pull policy If set to empty, then Kubernetes default behaviour applies. |
+| image.registry | string | `"ghcr.io"` | Operator image registry |
+| image.repository | string | `"vshn/appcat-service-postgresql"` | Operator image repository |
+| image.tag | string | `"latest"` | Operator image tag |
+| imagePullSecrets | list | `[]` | List of image pull secrets if custom image is behind authentication. |
+| nameOverride | string | `""` |  |
+| nodeSelector | object | `{}` |  |
+| operator.args | list | `[]` | Overrides arguments passed to the entrypoint |
+| podAnnotations | object | `{}` | Annotations to add to the Pod spec. |
+| podSecurityContext | object | `{}` | Security context to add to the Pod spec. |
+| replicaCount | int | `1` | How many operator pods should run. Follower pods reduce interruption time as they're on hot standby when leader is unresponsive. |
+| resources | object | `{}` |  |
+| securityContext | object | `{}` | Container security context |
+| service.port | int | `80` | Service port number |
+| service.type | string | `"ClusterIP"` | Service type |
+| serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
+| serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
+| serviceAccount.name | string | `""` | The name of the service account to use. If not set and `.create` is `true`, a name is generated using the fullname template |
+| tolerations | list | `[]` |  |
+| webhook.caBundle | string | `""` | Certificate in PEM format for the ValidatingWebhookConfiguration. |
+| webhook.certificate | string | `""` | Certificate in PEM format for the TLS secret. |
+| webhook.privateKey | string | `""` | Private key in PEM format for the TLS secret. |
+
+<!---
+Common/Useful Link references from values.yaml
+-->
+[resource-units]: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-units-in-kubernetes
+[prometheus-operator]: https://github.com/coreos/prometheus-operator

--- a/appuio/appcat-service-postgresql/templates/NOTES.txt
+++ b/appuio/appcat-service-postgresql/templates/NOTES.txt
@@ -1,0 +1,16 @@
+1. Get the application URL by running these commands:
+{{- if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "provider-postgresql.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "provider-postgresql.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "provider-postgresql.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "provider-postgresql.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/appuio/appcat-service-postgresql/templates/_helpers.tpl
+++ b/appuio/appcat-service-postgresql/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "provider-postgresql.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "provider-postgresql.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "provider-postgresql.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "provider-postgresql.labels" -}}
+helm.sh/chart: {{ include "provider-postgresql.chart" . }}
+{{ include "provider-postgresql.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "provider-postgresql.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "provider-postgresql.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "provider-postgresql.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "provider-postgresql.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/appuio/appcat-service-postgresql/templates/clusterrole.yaml
+++ b/appuio/appcat-service-postgresql/templates/clusterrole.yaml
@@ -1,0 +1,103 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: '{{ include "provider-postgresql.fullname" . }}'
+  labels:
+    {{- include "provider-postgresql.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - get
+      - list
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - helm.crossplane.io
+    resources:
+      - providerconfigs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - helm.crossplane.io
+    resources:
+      - releases
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - postgresql.appcat.vshn.io
+    resources:
+      - postgresqlstandaloneoperatorconfigs
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - postgresql.appcat.vshn.io
+    resources:
+      - postgresqlstandaloneoperatorconfigs/finalizers
+      - postgresqlstandaloneoperatorconfigs/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - postgresql.appcat.vshn.io
+    resources:
+      - postgresqlstandalones
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - postgresql.appcat.vshn.io
+    resources:
+      - postgresqlstandalones/finalizers
+      - postgresqlstandalones/status
+    verbs:
+      - get
+      - patch
+      - update

--- a/appuio/appcat-service-postgresql/templates/clusterrolebinding.yaml
+++ b/appuio/appcat-service-postgresql/templates/clusterrolebinding.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "provider-postgresql.fullname" . }}
+  labels:
+    {{- include "provider-postgresql.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "provider-postgresql.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "provider-postgresql.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/appuio/appcat-service-postgresql/templates/deployment.yaml
+++ b/appuio/appcat-service-postgresql/templates/deployment.yaml
@@ -1,0 +1,72 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "provider-postgresql.fullname" . }}
+  labels:
+    {{- include "provider-postgresql.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "provider-postgresql.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "provider-postgresql.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "provider-postgresql.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: operator
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: WEBHOOK_TLS_CERT_DIR
+              value: /webhook/tls
+          args:
+            {{- toYaml .Values.operator.args | nindent 12 }}
+          ports:
+            - name: webhook
+              containerPort: 9443
+              protocol: TCP
+          # livenessProbe:
+          #   httpGet:
+          #     path: /
+          #     port: webhook
+          # readinessProbe:
+          #   httpGet:
+          #     path: /
+          #     port: webhook
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: webhook-tls
+              readOnly: true
+              mountPath: /webhook/tls
+      volumes:
+        - name: webhook-tls
+          secret:
+            secretName: {{ include "provider-postgresql.fullname" . }}-webhook-tls
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/appuio/appcat-service-postgresql/templates/secret.yaml
+++ b/appuio/appcat-service-postgresql/templates/secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "provider-postgresql.fullname" . }}-webhook-tls
+  labels:
+    {{- include "provider-postgresql.labels" . | nindent 4 }}
+data:
+  tls.crt: {{ .Values.webhook.certificate }}
+  tls.key: {{ .Values.webhook.privateKey }}

--- a/appuio/appcat-service-postgresql/templates/service.yaml
+++ b/appuio/appcat-service-postgresql/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "provider-postgresql.fullname" . }}
+  labels:
+    {{- include "provider-postgresql.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+    - port: 443
+      targetPort: webhook
+      protocol: TCP
+      name: webhook
+  selector:
+    {{- include "provider-postgresql.selectorLabels" . | nindent 4 }}

--- a/appuio/appcat-service-postgresql/templates/serviceaccount.yaml
+++ b/appuio/appcat-service-postgresql/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "provider-postgresql.serviceAccountName" . }}
+  labels:
+    {{- include "provider-postgresql.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/appuio/appcat-service-postgresql/templates/webhook.yaml
+++ b/appuio/appcat-service-postgresql/templates/webhook.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: '{{ include "provider-postgresql.fullname" . }}'
+  labels:
+    {{- include "provider-postgresql.labels" . | nindent 4 }}
+webhooks:
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: '{{ include "provider-postgresql.fullname" . }}'
+        namespace: '{{ .Release.Namespace }}'
+        path: /validate-postgresql-appcat-vshn-io-v1alpha1-postgresqlstandalone
+      caBundle: '{{ .Values.webhook.caBundle }}'
+    failurePolicy: Fail
+    name: postgresqlstandalones.postgresql.appcat.vshn.io
+    rules:
+      - apiGroups:
+          - postgresql.appcat.vshn.io
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+          - DELETE
+        resources:
+          - postgresqlstandalones
+    sideEffects: None

--- a/appuio/appcat-service-postgresql/values.yaml
+++ b/appuio/appcat-service-postgresql/values.yaml
@@ -1,0 +1,80 @@
+# Default values for provider-postgresql.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# -- How many operator pods should run.
+# Follower pods reduce interruption time as they're on hot standby when leader is unresponsive.
+replicaCount: 1
+
+image:
+  # -- Operator image registry
+  registry: ghcr.io
+  # -- Operator image repository
+  repository: vshn/appcat-service-postgresql
+  # -- Operator image pull policy
+  # If set to empty, then Kubernetes default behaviour applies.
+  pullPolicy: IfNotPresent
+  # -- Operator image tag
+  tag: latest
+
+operator:
+  # -- Overrides arguments passed to the entrypoint
+  args: []
+
+# -- List of image pull secrets if custom image is behind authentication.
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # -- Specifies whether a service account should be created
+  create: true
+  # -- Annotations to add to the service account
+  annotations: {}
+  # -- The name of the service account to use.
+  # If not set and `.create` is `true`, a name is generated using the fullname template
+  name: ""
+
+# -- Annotations to add to the Pod spec.
+podAnnotations: {}
+
+# -- Security context to add to the Pod spec.
+podSecurityContext: {}
+  # fsGroup: 2000
+
+# -- Container security context
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  # -- Service type
+  type: ClusterIP
+  # -- Service port number
+  port: 80
+
+webhook:
+  # -- Certificate in PEM format for the ValidatingWebhookConfiguration.
+  caBundle: ""
+  # -- Certificate in PEM format for the TLS secret.
+  certificate: ""
+  # -- Private key in PEM format for the TLS secret.
+  privateKey: ""
+
+resources: {}
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
Signed-off-by: Gabriel Saratura <gabriel.saratura@vshn.ch>

<!--
Thank you for contributing to appuio/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

-->

#### What this PR does / why we need it:

Adding temporarily the new chart fort the appcat-service-postgresql in appuio domain.

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] I have run `make docs`
- [x] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] PR contains the label that identifies the chart, e.g. `chart/<chart-name>`
- [x] PR contains the label that identifies the type of change, which is one of
      [ `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency` ]
