### PR TITLE
Pin Bitnami index.yaml to pre-cleanup version

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,17 +21,17 @@ helm repo add appuio https://charts.appuio.ch
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/generic-0.1.2/total)](https://github.com/appuio/charts/releases/tag/generic-0.1.2) | [generic](appuio/generic/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/haproxy-2.0.2/total)](https://github.com/appuio/charts/releases/tag/haproxy-2.0.2) | [haproxy](appuio/haproxy/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/k8up-2.0.4/total)](https://github.com/appuio/charts/releases/tag/k8up-2.0.4) | [k8up](appuio/k8up/README.md) |
-| [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/mariadb-galera-1.2.3/total)](https://github.com/appuio/charts/releases/tag/mariadb-galera-1.2.3) | [mariadb-galera](appuio/mariadb-galera/README.md) |
+| [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/mariadb-galera-1.2.4/total)](https://github.com/appuio/charts/releases/tag/mariadb-galera-1.2.4) | [mariadb-galera](appuio/mariadb-galera/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/maxscale-1.1.2/total)](https://github.com/appuio/charts/releases/tag/maxscale-1.1.2) | [maxscale](appuio/maxscale/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/metrics-server-2.12.1/total)](https://github.com/appuio/charts/releases/tag/metrics-server-2.12.1) | [metrics-server](appuio/metrics-server/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/openshift-oauth-proxy-0.2.3/total)](https://github.com/appuio/charts/releases/tag/openshift-oauth-proxy-0.2.3) | [openshift-oauth-proxy](appuio/openshift-oauth-proxy/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/openshift-route-1.1.4/total)](https://github.com/appuio/charts/releases/tag/openshift-route-1.1.4) | [openshift-route](appuio/openshift-route/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/prometheus-blackbox-exporter-0.3.1/total)](https://github.com/appuio/charts/releases/tag/prometheus-blackbox-exporter-0.3.1) | [prometheus-blackbox-exporter](appuio/prometheus-blackbox-exporter/README.md) |
-| [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/redis-1.3.4/total)](https://github.com/appuio/charts/releases/tag/redis-1.3.4) | [redis](appuio/redis/README.md) |
+| [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/redis-1.3.5/total)](https://github.com/appuio/charts/releases/tag/redis-1.3.5) | [redis](appuio/redis/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/secret-1.1.0/total)](https://github.com/appuio/charts/releases/tag/secret-1.1.0) | [secret](appuio/secret/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/signalilo-0.7.0/total)](https://github.com/appuio/charts/releases/tag/signalilo-0.7.0) | [signalilo](appuio/signalilo/README.md) |
-| [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/snappass-0.2.14/total)](https://github.com/appuio/charts/releases/tag/snappass-0.2.14) | [snappass](appuio/snappass/README.md) |
-| [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/stardog-0.11.0/total)](https://github.com/appuio/charts/releases/tag/stardog-0.11.0) | [stardog](appuio/stardog/README.md) |
+| [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/snappass-0.2.15/total)](https://github.com/appuio/charts/releases/tag/snappass-0.2.15) | [snappass](appuio/snappass/README.md) |
+| [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/stardog-0.11.1/total)](https://github.com/appuio/charts/releases/tag/stardog-0.11.1) | [stardog](appuio/stardog/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/stardog-userrole-operator-0.1.0/total)](https://github.com/appuio/charts/releases/tag/stardog-userrole-operator-0.1.0) | [stardog-userrole-operator](appuio/stardog-userrole-operator/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/trifid-1.2.2/total)](https://github.com/appuio/charts/releases/tag/trifid-1.2.2) | [trifid](appuio/trifid/README.md) |
 

--- a/appuio/mariadb-galera/Chart.lock
+++ b/appuio/mariadb-galera/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
-  repository: https://charts.bitnami.com/bitnami
-  version: 1.8.0
-digest: sha256:3e342a25057f87853e52d83e1d14e6d8727c15fd85aaae22e7594489cc129f15
-generated: "2021-08-24T14:45:08.299019813Z"
+  repository: https://raw.githubusercontent.com/bitnami/charts/defb094c658024e4aa8245622dab202874880cbc/bitnami/
+  version: 1.15.1
+digest: sha256:76450f70ef67b89d955bfb644f899d17edbcec9ad0208d686bc4cd11f006d7ae
+generated: "2022-06-10T00:59:32.675836+02:00"

--- a/appuio/mariadb-galera/Chart.yaml
+++ b/appuio/mariadb-galera/Chart.yaml
@@ -4,7 +4,8 @@ apiVersion: v2
 appVersion: 10.5.12
 dependencies:
   - name: common
-    repository: https://charts.bitnami.com/bitnami
+    # Pinned to index.yaml before upstream cleanup (see: https://github.com/bitnami/charts/pull/10530)
+    repository: https://raw.githubusercontent.com/bitnami/charts/defb094c658024e4aa8245622dab202874880cbc/bitnami/
     tags:
       - bitnami-common
     version: 1.x.x
@@ -27,4 +28,4 @@ sources:
   - https://github.com/bitnami/bitnami-docker-mariadb-galera
   - https://github.com/prometheus/mysqld_exporter
   - https://mariadb.org
-version: 1.2.3
+version: 1.2.4

--- a/appuio/mariadb-galera/README.md
+++ b/appuio/mariadb-galera/README.md
@@ -1,6 +1,6 @@
 # mariadb-galera
 
-![Version: 1.2.3](https://img.shields.io/badge/Version-1.2.3-informational?style=flat-square) ![AppVersion: 10.5.12](https://img.shields.io/badge/AppVersion-10.5.12-informational?style=flat-square)
+![Version: 1.2.4](https://img.shields.io/badge/Version-1.2.4-informational?style=flat-square) ![AppVersion: 10.5.12](https://img.shields.io/badge/AppVersion-10.5.12-informational?style=flat-square)
 
 MariaDB Galera is a multi-master database cluster solution for synchronous replication and high availability.
 
@@ -181,7 +181,7 @@ Edit the README.gotmpl.md template instead.
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | common | 1.x.x |
+| https://raw.githubusercontent.com/bitnami/charts/defb094c658024e4aa8245622dab202874880cbc/bitnami/ | common | 1.x.x |
 
 <!---
 Common/Useful Link references from values.yaml

--- a/appuio/redis/Chart.lock
+++ b/appuio/redis/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
-  repository: https://charts.bitnami.com/bitnami
-  version: 1.4.2
-digest: sha256:4e3ec38e0e27e9fc1defb2a13f67a0aa12374bf0b15f06a6c13b1b46df6bffeb
-generated: "2021-04-05T11:40:59.141264592Z"
+  repository: https://raw.githubusercontent.com/bitnami/charts/defb094c658024e4aa8245622dab202874880cbc/bitnami/
+  version: 1.15.1
+digest: sha256:76450f70ef67b89d955bfb644f899d17edbcec9ad0208d686bc4cd11f006d7ae
+generated: "2022-06-10T00:58:40.801311+02:00"

--- a/appuio/redis/Chart.yaml
+++ b/appuio/redis/Chart.yaml
@@ -4,7 +4,8 @@ apiVersion: v2
 appVersion: 6.2.1
 dependencies:
 - name: common
-  repository: https://charts.bitnami.com/bitnami
+  # Pinned to index.yaml before upstream cleanup (see: https://github.com/bitnami/charts/pull/10530)
+  repository: https://raw.githubusercontent.com/bitnami/charts/defb094c658024e4aa8245622dab202874880cbc/bitnami/
   tags:
   - bitnami-common
   version: 1.x.x
@@ -24,4 +25,4 @@ name: redis
 sources:
 - https://github.com/bitnami/bitnami-docker-redis
 - http://redis.io/
-version: 1.3.4
+version: 1.3.5

--- a/appuio/redis/README.md
+++ b/appuio/redis/README.md
@@ -1,6 +1,6 @@
 # redis
 
-![Version: 1.3.4](https://img.shields.io/badge/Version-1.3.4-informational?style=flat-square) ![AppVersion: 6.2.1](https://img.shields.io/badge/AppVersion-6.2.1-informational?style=flat-square)
+![Version: 1.3.5](https://img.shields.io/badge/Version-1.3.5-informational?style=flat-square) ![AppVersion: 6.2.1](https://img.shields.io/badge/AppVersion-6.2.1-informational?style=flat-square)
 
 Open source, advanced key-value store. It is often referred to as a data structure server since keys can contain strings, hashes, lists, sets and sorted sets.
 
@@ -250,7 +250,7 @@ Edit the README.gotmpl.md template instead.
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | common | 1.x.x |
+| https://raw.githubusercontent.com/bitnami/charts/defb094c658024e4aa8245622dab202874880cbc/bitnami/ | common | 1.x.x |
 
 <!---
 Common/Useful Link references from values.yaml

--- a/appuio/snappass/Chart.yaml
+++ b/appuio/snappass/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: snappass
 description: A Helm chart for SnapPass
-version: 0.2.14
+version: 0.2.15
 appVersion: v1.4.2
 sources:
 - https://github.com/pinterest/snappass

--- a/appuio/snappass/Makefile
+++ b/appuio/snappass/Makefile
@@ -12,6 +12,6 @@ help: ## Show this help
 #
 # "Interface" for parent Makefile
 #
-prepare: ## Build dependencies for this chart
-	helm repo add bitnami https://charts.bitnami.com/bitnami
+prepare: ## Build dependencies for this chart - pinned to index.yaml before upstream cleanup (see: https://github.com/bitnami/charts/pull/10530)
+	helm repo add bitnami https://raw.githubusercontent.com/bitnami/charts/defb094c658024e4aa8245622dab202874880cbc/bitnami/
 	helm dep build

--- a/appuio/snappass/README.md
+++ b/appuio/snappass/README.md
@@ -1,6 +1,6 @@
 # snappass
 
-![Version: 0.2.14](https://img.shields.io/badge/Version-0.2.14-informational?style=flat-square) ![AppVersion: v1.4.2](https://img.shields.io/badge/AppVersion-v1.4.2-informational?style=flat-square)
+![Version: 0.2.15](https://img.shields.io/badge/Version-0.2.15-informational?style=flat-square) ![AppVersion: v1.4.2](https://img.shields.io/badge/AppVersion-v1.4.2-informational?style=flat-square)
 
 A Helm chart for SnapPass
 
@@ -71,7 +71,7 @@ Edit the README.gotmpl.md template instead.
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | redis | 10.7.4 |
+| https://raw.githubusercontent.com/bitnami/charts/defb094c658024e4aa8245622dab202874880cbc/bitnami/ | redis | 10.7.4 |
 
 <!---
 Common/Useful Link references from values.yaml

--- a/appuio/snappass/requirements.lock
+++ b/appuio/snappass/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: redis
-  repository: https://charts.bitnami.com/bitnami
+  repository: https://raw.githubusercontent.com/bitnami/charts/defb094c658024e4aa8245622dab202874880cbc/bitnami/
   version: 10.7.4
-digest: sha256:83ddb3329243b16e31a7c363cb7aa59a80fc9ef6483788bcef003966f759d67c
-generated: "2020-06-19T14:38:05.224051+02:00"
+digest: sha256:7e7842fb969db4fb54d3a34dd2fd8f906330f7a20fe05e0445f8ee1a93e07365
+generated: "2022-06-10T00:47:10.568495+02:00"

--- a/appuio/snappass/requirements.yaml
+++ b/appuio/snappass/requirements.yaml
@@ -1,5 +1,6 @@
 dependencies:
   - name: redis
     version: 10.7.4
-    repository: https://charts.bitnami.com/bitnami
+    # Pinned to index.yaml before upstream cleanup (see: https://github.com/bitnami/charts/pull/10530)
+    repository: https://raw.githubusercontent.com/bitnami/charts/defb094c658024e4aa8245622dab202874880cbc/bitnami/
     condition: redis.enabled

--- a/appuio/stardog/Chart.yaml
+++ b/appuio/stardog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: stardog
-version: 0.11.0
+version: 0.11.1
 appVersion: 7.9.0
 description: Stardog is the world’s leading knowledge graph platform for the enterprise. Stardog makes it fast and easy to turn enterprise data into knowledge.
 home: "https://www.stardog.com/"

--- a/appuio/stardog/Makefile
+++ b/appuio/stardog/Makefile
@@ -12,6 +12,6 @@ help: ## Show this help
 #
 # "Interface" for parent Makefile
 #
-prepare: ## Build dependencies for this chart
-	helm repo add bitnami https://charts.bitnami.com/bitnami
+prepare: ## Build dependencies for this chart - pinned to index.yaml before upstream cleanup (see: https://github.com/bitnami/charts/pull/10530)
+	helm repo add bitnami https://raw.githubusercontent.com/bitnami/charts/defb094c658024e4aa8245622dab202874880cbc/bitnami/
 	helm dep build

--- a/appuio/stardog/README.md
+++ b/appuio/stardog/README.md
@@ -1,6 +1,6 @@
 # stardog
 
-![Version: 0.11.0](https://img.shields.io/badge/Version-0.11.0-informational?style=flat-square) ![AppVersion: 7.9.0](https://img.shields.io/badge/AppVersion-7.9.0-informational?style=flat-square)
+![Version: 0.11.1](https://img.shields.io/badge/Version-0.11.1-informational?style=flat-square) ![AppVersion: 7.9.0](https://img.shields.io/badge/AppVersion-7.9.0-informational?style=flat-square)
 
 Stardog is the world’s leading knowledge graph platform for the enterprise. Stardog makes it fast and easy to turn enterprise data into knowledge.
 
@@ -85,7 +85,7 @@ The following table lists the configurable parameters chart. For default values 
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | zookeeper | 5.14.4 |
+| https://raw.githubusercontent.com/bitnami/charts/defb094c658024e4aa8245622dab202874880cbc/bitnami/ | zookeeper | 5.14.4 |
 
 <!---
 Common/Useful Link references from values.yaml

--- a/appuio/stardog/requirements.lock
+++ b/appuio/stardog/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: zookeeper
-  repository: https://charts.bitnami.com/bitnami
+  repository: https://raw.githubusercontent.com/bitnami/charts/defb094c658024e4aa8245622dab202874880cbc/bitnami/
   version: 5.14.4
-digest: sha256:13a0276f894f6e6d74de482084ac1bb11df201a626ec389c26ee59c8de4ab6bf
-generated: "2021-11-18T16:25:28.265918208+01:00"
+digest: sha256:308cbf9ab3717873b228237c3a25443bf984eab6ee58d00441365b4fa2fd4083
+generated: "2022-06-10T00:46:25.930974+02:00"

--- a/appuio/stardog/requirements.yaml
+++ b/appuio/stardog/requirements.yaml
@@ -1,5 +1,6 @@
 dependencies:
   - name: zookeeper
     version: 5.14.4
-    repository: https://charts.bitnami.com/bitnami
+    # Pinned to index.yaml before upstream cleanup (see: https://github.com/bitnami/charts/pull/10530)
+    repository: https://raw.githubusercontent.com/bitnami/charts/defb094c658024e4aa8245622dab202874880cbc/bitnami/
     condition: zookeeper.enabled


### PR DESCRIPTION
#### What this PR does / why we need it:

Bitnami cleaned up their upstream index.yaml in https://github.com/bitnami/charts/pull/10530 which makes old charts unresolvable.

This is a mid-term fix allowing us to release new chart versions until we have updated and tested all Bitnami chart dependencies.

Fixes #426

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] Chart Version bumped
- [x] I have run `make docs`
- [x] PR contains the label that identifies the chart, e.g. `chart/<chart-name>`
- [x] PR contains the label that identifies the type of change, which is one of
      [ `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency` ]
