### PR TITLE
New probe timeouts for Trifid

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ helm repo add appuio https://charts.appuio.ch
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/snappass-0.2.15/total)](https://github.com/appuio/charts/releases/tag/snappass-0.2.15) | [snappass](appuio/snappass/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/stardog-0.11.2/total)](https://github.com/appuio/charts/releases/tag/stardog-0.11.2) | [stardog](appuio/stardog/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/stardog-userrole-operator-0.1.1/total)](https://github.com/appuio/charts/releases/tag/stardog-userrole-operator-0.1.1) | [stardog-userrole-operator](appuio/stardog-userrole-operator/README.md) |
-| [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/trifid-1.2.2/total)](https://github.com/appuio/charts/releases/tag/trifid-1.2.2) | [trifid](appuio/trifid/README.md) |
+| [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/trifid-1.2.3/total)](https://github.com/appuio/charts/releases/tag/trifid-1.2.3) | [trifid](appuio/trifid/README.md) |
 
 ## Add / Update Charts
 

--- a/appuio/trifid/Chart.yaml
+++ b/appuio/trifid/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: trifid
 description: Trifid provides a lightweight and easy way to access Linked Data URIs via HTTP.
-version: 1.2.2
+version: 1.2.3
 appVersion: 2.3.7
 home: "https://github.com/zazuko/trifid"
 sources:

--- a/appuio/trifid/README.md
+++ b/appuio/trifid/README.md
@@ -1,6 +1,6 @@
 # trifid
 
-![Version: 1.2.2](https://img.shields.io/badge/Version-1.2.2-informational?style=flat-square) ![AppVersion: 2.3.7](https://img.shields.io/badge/AppVersion-2.3.7-informational?style=flat-square)
+![Version: 1.2.3](https://img.shields.io/badge/Version-1.2.3-informational?style=flat-square) ![AppVersion: 2.3.7](https://img.shields.io/badge/AppVersion-2.3.7-informational?style=flat-square)
 
 Trifid provides a lightweight and easy way to access Linked Data URIs via HTTP.
 

--- a/appuio/trifid/templates/deployment.yaml
+++ b/appuio/trifid/templates/deployment.yaml
@@ -50,10 +50,17 @@ spec:
               path: /
               port: http
             initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
           readinessProbe:
             httpGet:
               path: /
               port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}


### PR DESCRIPTION
New readiness and liveness probes to more reliably start Trifid pods.

#### What this PR does / why we need it:

* Short summary

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] Chart Version bumped
- [x] I have run `make docs`
- [x] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] PR contains the label that identifies the chart, e.g. `chart/<chart-name>`
- [x] PR contains the label that identifies the type of change, which is one of
      [ `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency` ]
