### PR TITLE
Upgrade Stardog to 8.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ helm repo add appuio https://charts.appuio.ch
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/secret-1.1.0/total)](https://github.com/appuio/charts/releases/tag/secret-1.1.0) | [secret](appuio/secret/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/signalilo-0.7.0/total)](https://github.com/appuio/charts/releases/tag/signalilo-0.7.0) | [signalilo](appuio/signalilo/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/snappass-0.2.15/total)](https://github.com/appuio/charts/releases/tag/snappass-0.2.15) | [snappass](appuio/snappass/README.md) |
-| [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/stardog-0.11.2/total)](https://github.com/appuio/charts/releases/tag/stardog-0.11.2) | [stardog](appuio/stardog/README.md) |
+| [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/stardog-0.12.0/total)](https://github.com/appuio/charts/releases/tag/stardog-0.12.0) | [stardog](appuio/stardog/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/stardog-userrole-operator-0.1.1/total)](https://github.com/appuio/charts/releases/tag/stardog-userrole-operator-0.1.1) | [stardog-userrole-operator](appuio/stardog-userrole-operator/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/trifid-1.2.3/total)](https://github.com/appuio/charts/releases/tag/trifid-1.2.3) | [trifid](appuio/trifid/README.md) |
 

--- a/appuio/stardog/Chart.yaml
+++ b/appuio/stardog/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: stardog
-version: 0.11.2
-appVersion: 8.0.1
+version: 0.12.0
+appVersion: 8.1.0
 description: Stardog is the world’s leading knowledge graph platform for the enterprise. Stardog makes it fast and easy to turn enterprise data into knowledge.
 home: "https://www.stardog.com/"
 icon: https://d33wubrfki0l68.cloudfront.net/img/c920235ff153186ab17617ce2bce193d867fa80c/stardog-logo.png

--- a/appuio/stardog/Makefile
+++ b/appuio/stardog/Makefile
@@ -13,5 +13,5 @@ help: ## Show this help
 # "Interface" for parent Makefile
 #
 prepare:
-	helm repo add bitnami https://charts.bitnami.com/bitnami
+	helm repo add bitnami-latest https://charts.bitnami.com/bitnami
 	helm dep build

--- a/appuio/stardog/Makefile
+++ b/appuio/stardog/Makefile
@@ -12,6 +12,6 @@ help: ## Show this help
 #
 # "Interface" for parent Makefile
 #
-prepare: ## Build dependencies for this chart - pinned to index.yaml before upstream cleanup (see: https://github.com/bitnami/charts/pull/10530)
-	helm repo add bitnami https://raw.githubusercontent.com/bitnami/charts/defb094c658024e4aa8245622dab202874880cbc/bitnami/
+prepare:
+	helm repo add bitnami https://charts.bitnami.com/bitnami
 	helm dep build

--- a/appuio/stardog/README.gotmpl.md
+++ b/appuio/stardog/README.gotmpl.md
@@ -57,7 +57,6 @@ The following table lists the configurable parameters chart. For default values 
 | `zookeeper.enabled`                          | Enable ZooKeeper. Required for Stardog Cluster deployments |
 | `zookeeper.replicaCount`                     | Number of ZooKeeper instances to run. Should always be an odd number > 3 |
 | `zookeeper.updateStrategy`                   | [Update strategy](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies) of the ZooKeeper StatefulSet |
-| `zookeeper.allowAnonymousLogin`              | Allow anonymous logins to ZooKeeper |
 | `zookeeper.auth.enabled`                     | Enable ZooKeeper authentication |
 | `zookeeper.auth.clientPassword`              | Password to use for ZooKeeper clients. Will be generated if unset |
 | `zookeeper.auth.serverPasswords`             | Password to use for ZooKeeper servers (delimited by `,`). Will be generated if unset |

--- a/appuio/stardog/README.md
+++ b/appuio/stardog/README.md
@@ -71,7 +71,6 @@ The following table lists the configurable parameters chart. For default values 
 | `zookeeper.enabled`                          | Enable ZooKeeper. Required for Stardog Cluster deployments |
 | `zookeeper.replicaCount`                     | Number of ZooKeeper instances to run. Should always be an odd number > 3 |
 | `zookeeper.updateStrategy`                   | [Update strategy](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies) of the ZooKeeper StatefulSet |
-| `zookeeper.allowAnonymousLogin`              | Allow anonymous logins to ZooKeeper |
 | `zookeeper.auth.enabled`                     | Enable ZooKeeper authentication |
 | `zookeeper.auth.clientPassword`              | Password to use for ZooKeeper clients. Will be generated if unset |
 | `zookeeper.auth.serverPasswords`             | Password to use for ZooKeeper servers (delimited by `,`). Will be generated if unset |

--- a/appuio/stardog/README.md
+++ b/appuio/stardog/README.md
@@ -1,6 +1,6 @@
 # stardog
 
-![Version: 0.11.2](https://img.shields.io/badge/Version-0.11.2-informational?style=flat-square) ![AppVersion: 8.0.1](https://img.shields.io/badge/AppVersion-8.0.1-informational?style=flat-square)
+![Version: 0.12.0](https://img.shields.io/badge/Version-0.12.0-informational?style=flat-square) ![AppVersion: 8.1.0](https://img.shields.io/badge/AppVersion-8.1.0-informational?style=flat-square)
 
 Stardog is the world’s leading knowledge graph platform for the enterprise. Stardog makes it fast and easy to turn enterprise data into knowledge.
 
@@ -85,7 +85,7 @@ The following table lists the configurable parameters chart. For default values 
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://raw.githubusercontent.com/bitnami/charts/defb094c658024e4aa8245622dab202874880cbc/bitnami/ | zookeeper | 5.14.4 |
+| https://charts.bitnami.com/bitnami | zookeeper | 8.1.2 |
 
 <!---
 Common/Useful Link references from values.yaml

--- a/appuio/stardog/requirements.lock
+++ b/appuio/stardog/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: zookeeper
-  repository: https://raw.githubusercontent.com/bitnami/charts/defb094c658024e4aa8245622dab202874880cbc/bitnami/
-  version: 5.14.4
-digest: sha256:308cbf9ab3717873b228237c3a25443bf984eab6ee58d00441365b4fa2fd4083
-generated: "2022-06-10T00:46:25.930974+02:00"
+  repository: https://charts.bitnami.com/bitnami
+  version: 8.1.2
+digest: sha256:f1f8723c9a4a535ff8d53eb325406d5554e453358e2e8364494601b3e4231976
+generated: "2022-09-28T11:34:24.327474146+02:00"

--- a/appuio/stardog/requirements.yaml
+++ b/appuio/stardog/requirements.yaml
@@ -1,6 +1,7 @@
 dependencies:
   - name: zookeeper
-    version: 5.14.4
+    version: 8.1.2
     # Pinned to index.yaml before upstream cleanup (see: https://github.com/bitnami/charts/pull/10530)
-    repository: https://raw.githubusercontent.com/bitnami/charts/defb094c658024e4aa8245622dab202874880cbc/bitnami/
+    #repository: https://raw.githubusercontent.com/bitnami/charts/defb094c658024e4aa8245622dab202874880cbc/bitnami/
+    repository: https://charts.bitnami.com/bitnami
     condition: zookeeper.enabled

--- a/appuio/stardog/requirements.yaml
+++ b/appuio/stardog/requirements.yaml
@@ -1,7 +1,5 @@
 dependencies:
   - name: zookeeper
     version: 8.1.2
-    # Pinned to index.yaml before upstream cleanup (see: https://github.com/bitnami/charts/pull/10530)
-    #repository: https://raw.githubusercontent.com/bitnami/charts/defb094c658024e4aa8245622dab202874880cbc/bitnami/
     repository: https://charts.bitnami.com/bitnami
     condition: zookeeper.enabled

--- a/appuio/stardog/templates/_helpers.tpl
+++ b/appuio/stardog/templates/_helpers.tpl
@@ -37,7 +37,7 @@ Create chart name and version as used by the chart label.
 
 {{- define "stardog.zookeeper.fullname" -}}
 {{- $zookeeperContext := dict "Values" .Values.zookeeper "Release" .Release "Chart" (dict "Name" "zookeeper") -}}
-{{ template "zookeeper.fullname" $zookeeperContext }}
+{{ template "common.names.fullname" $zookeeperContext }}
 {{- end -}}
 
 {{/*

--- a/appuio/stardog/values.yaml
+++ b/appuio/stardog/values.yaml
@@ -104,8 +104,8 @@ memory:
 zookeeper:
   enabled: true
   replicaCount: 3
-  updateStrategy: OnDelete
-  allowAnonymousLogin: false
+  updateStrategy:
+    type: OnDelete
   sessionTimeout: 15s
   autopurge: # Without autopurge, the PV will run full
     purgeInterval: 6 # In hours

--- a/appuio/stardog/values.yaml
+++ b/appuio/stardog/values.yaml
@@ -11,7 +11,7 @@ image:
   registry: stardog-eps-docker.jfrog.io
   # username:
   # password:
-  tag: 8.0.1
+  tag: 8.1.0
   pullPolicy: IfNotPresent
   # existingPullSecret: my-image-pull-secret
 


### PR DESCRIPTION

#### What this PR does / why we need it:

* Upgrades Stardog to 8.1.0
* Upgrades the ZooKeeper dependency to Bitnami's 8.1.2 (app version 3.7.0)

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] Chart Version bumped
- [x] I have run `make docs`
- [x] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] PR contains the label that identifies the chart, e.g. `chart/<chart-name>`
- [x] PR contains the label that identifies the type of change, which is one of
      [ `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency` ]
