### PR TITLE
Ensure Stardog alert rules are picked up by Syn Prometheus

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - uses: azure/setup-helm@v1
+      - uses: azure/setup-helm@v3
+        with:
+          version: '3.9.0'
+        id: install
       - name: Determine Go version from go.mod
         run: echo "GO_VERSION=$(grep "go 1." go.mod | cut -d " " -f 2)" >> $GITHUB_ENV
       - uses: actions/setup-go@v2

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ helm repo add appuio https://charts.appuio.ch
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/secret-1.1.0/total)](https://github.com/appuio/charts/releases/tag/secret-1.1.0) | [secret](appuio/secret/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/signalilo-0.8.0/total)](https://github.com/appuio/charts/releases/tag/signalilo-0.8.0) | [signalilo](appuio/signalilo/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/snappass-0.2.15/total)](https://github.com/appuio/charts/releases/tag/snappass-0.2.15) | [snappass](appuio/snappass/README.md) |
-| [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/stardog-0.12.4/total)](https://github.com/appuio/charts/releases/tag/stardog-0.12.4) | [stardog](appuio/stardog/README.md) |
+| [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/stardog-0.12.5/total)](https://github.com/appuio/charts/releases/tag/stardog-0.12.5) | [stardog](appuio/stardog/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/stardog-userrole-operator-0.1.1/total)](https://github.com/appuio/charts/releases/tag/stardog-userrole-operator-0.1.1) | [stardog-userrole-operator](appuio/stardog-userrole-operator/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/trifid-1.2.3/total)](https://github.com/appuio/charts/releases/tag/trifid-1.2.3) | [trifid](appuio/trifid/README.md) |
 

--- a/appuio/stardog/Chart.yaml
+++ b/appuio/stardog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: stardog
-version: 0.12.4
+version: 0.12.5
 appVersion: 8.1.0
 description: Stardog is the world’s leading knowledge graph platform for the enterprise. Stardog makes it fast and easy to turn enterprise data into knowledge.
 home: "https://www.stardog.com/"

--- a/appuio/stardog/README.md
+++ b/appuio/stardog/README.md
@@ -1,6 +1,6 @@
 # stardog
 
-![Version: 0.12.4](https://img.shields.io/badge/Version-0.12.4-informational?style=flat-square) ![AppVersion: 8.1.0](https://img.shields.io/badge/AppVersion-8.1.0-informational?style=flat-square)
+![Version: 0.12.5](https://img.shields.io/badge/Version-0.12.5-informational?style=flat-square) ![AppVersion: 8.1.0](https://img.shields.io/badge/AppVersion-8.1.0-informational?style=flat-square)
 
 Stardog is the world’s leading knowledge graph platform for the enterprise. Stardog makes it fast and easy to turn enterprise data into knowledge.
 

--- a/appuio/stardog/templates/monitoring/stardog-java-rules.yaml
+++ b/appuio/stardog/templates/monitoring/stardog-java-rules.yaml
@@ -10,6 +10,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     role: alert-rules
+    monitoring.syn.tools/enabled: "true"
 spec:
   groups:
 

--- a/appuio/stardog/templates/monitoring/stardog-rules.yaml
+++ b/appuio/stardog/templates/monitoring/stardog-rules.yaml
@@ -10,6 +10,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     role: alert-rules
+    monitoring.syn.tools/enabled: "true"
 spec:
   groups:
   - name: Stardog

--- a/appuio/stardog/templates/monitoring/zookeeper-rules.yaml
+++ b/appuio/stardog/templates/monitoring/zookeeper-rules.yaml
@@ -10,6 +10,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     role: alert-rules
+    monitoring.syn.tools/enabled: "true"
 spec:
   groups:
   - name: zookeeper


### PR DESCRIPTION
#### What this PR does / why we need it:

* Fixed Stardog alerts not being picked up by Prometheus instances deployed using the Project Syn Prometheus component

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] Chart Version bumped
- [x] I have run `make docs`
- [x] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] PR contains the label that identifies the chart, e.g. `chart/<chart-name>`
- [x] PR contains the label that identifies the type of change, which is one of
      [ `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency` ]
