### PR TITLE
Allow specifying extra PrometheusRule labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ helm repo add appuio https://charts.appuio.ch
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/secret-1.1.0/total)](https://github.com/appuio/charts/releases/tag/secret-1.1.0) | [secret](appuio/secret/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/signalilo-0.8.0/total)](https://github.com/appuio/charts/releases/tag/signalilo-0.8.0) | [signalilo](appuio/signalilo/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/snappass-0.2.15/total)](https://github.com/appuio/charts/releases/tag/snappass-0.2.15) | [snappass](appuio/snappass/README.md) |
-| [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/stardog-0.13.0/total)](https://github.com/appuio/charts/releases/tag/stardog-0.13.0) | [stardog](appuio/stardog/README.md) |
+| [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/stardog-0.14.0/total)](https://github.com/appuio/charts/releases/tag/stardog-0.14.0) | [stardog](appuio/stardog/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/stardog-userrole-operator-0.1.1/total)](https://github.com/appuio/charts/releases/tag/stardog-userrole-operator-0.1.1) | [stardog-userrole-operator](appuio/stardog-userrole-operator/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/trifid-1.2.3/total)](https://github.com/appuio/charts/releases/tag/trifid-1.2.3) | [trifid](appuio/trifid/README.md) |
 

--- a/appuio/stardog/Chart.yaml
+++ b/appuio/stardog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: stardog
-version: 0.13.0
+version: 0.14.0
 appVersion: 8.1.1
 description: Stardog is the world’s leading knowledge graph platform for the enterprise. Stardog makes it fast and easy to turn enterprise data into knowledge.
 home: "https://www.stardog.com/"

--- a/appuio/stardog/README.gotmpl.md
+++ b/appuio/stardog/README.gotmpl.md
@@ -50,6 +50,7 @@ The following table lists the configurable parameters chart. For default values 
 | `ingress.host`                               | Host name which the ingress should resolve |
 | `ingress.tls.enabled`                        | If TLS should be enabled on the ingress |
 | `ingress.tls.secretName`                     | Name of the secret containing the TLS certificate and key |
+| `metrics.extraRuleLabels`        | A hash of labels to add to every PrometheusRule |
 | `persistence.enabled`                        | Enable persistence using PVC |
 | `persistence.storageClass`                   | PVC storage class for Stardog data volume |
 | `persistence.size`                           | PVC storage request size for Stardog data volume |
@@ -65,3 +66,4 @@ The following table lists the configurable parameters chart. For default values 
 | `zookeeper.sessionTimeout`                   | Set the ZooKeeper [session timeout](https://docs.stardog.com/cluster/installation-and-setup/#connectionsession-timeouts) |
 | `zookeeper.autopurge.snapRetainCount`        | How many snapshots ZooKeeper should keep when [autopurging](https://zookeeper.apache.org/doc/r3.4.5/zookeeperAdmin.html#sc_strengthsAndLimitations) |
 | `zookeeper.autopurge.purgeInterval`        | Interval (in hours) for ZooKeeper autopurge |
+

--- a/appuio/stardog/README.md
+++ b/appuio/stardog/README.md
@@ -1,6 +1,6 @@
 # stardog
 
-![Version: 0.13.0](https://img.shields.io/badge/Version-0.13.0-informational?style=flat-square) ![AppVersion: 8.1.1](https://img.shields.io/badge/AppVersion-8.1.1-informational?style=flat-square)
+![Version: 0.14.0](https://img.shields.io/badge/Version-0.14.0-informational?style=flat-square) ![AppVersion: 8.1.1](https://img.shields.io/badge/AppVersion-8.1.1-informational?style=flat-square)
 
 Stardog is the world’s leading knowledge graph platform for the enterprise. Stardog makes it fast and easy to turn enterprise data into knowledge.
 
@@ -64,6 +64,7 @@ The following table lists the configurable parameters chart. For default values 
 | `ingress.host`                               | Host name which the ingress should resolve |
 | `ingress.tls.enabled`                        | If TLS should be enabled on the ingress |
 | `ingress.tls.secretName`                     | Name of the secret containing the TLS certificate and key |
+| `metrics.extraRuleLabels`        | A hash of labels to add to every PrometheusRule |
 | `persistence.enabled`                        | Enable persistence using PVC |
 | `persistence.storageClass`                   | PVC storage class for Stardog data volume |
 | `persistence.size`                           | PVC storage request size for Stardog data volume |

--- a/appuio/stardog/templates/_helpers.tpl
+++ b/appuio/stardog/templates/_helpers.tpl
@@ -40,6 +40,15 @@ Create chart name and version as used by the chart label.
 {{ template "common.names.fullname" $zookeeperContext }}
 {{- end -}}
 
+{{- define "prometheusRules.extraLabels" -}}
+{{- if .Values.metrics.extraRuleLabels -}}
+{{- range $key, $val := .Values.metrics.extraRuleLabels }}
+{{ $key }}: {{ $val | quote }}
+{{- end }}
+{{- else -}}
+{{- end -}}
+{{- end -}}
+
 {{/*
 Create ZooKeeper connection string.
 */}}

--- a/appuio/stardog/templates/monitoring/stardog-rules.yaml
+++ b/appuio/stardog/templates/monitoring/stardog-rules.yaml
@@ -10,6 +10,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     role: alert-rules
+    {{- include "prometheusRules.extraLabels" . | indent 4 }}
 spec:
   groups:
   - name: Stardog

--- a/appuio/stardog/templates/monitoring/zookeeper-rules.yaml
+++ b/appuio/stardog/templates/monitoring/zookeeper-rules.yaml
@@ -10,6 +10,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     role: alert-rules
+    {{- include "prometheusRules.extraLabels" . | indent 4 }}
 spec:
   groups:
   - name: zookeeper

--- a/appuio/stardog/values.yaml
+++ b/appuio/stardog/values.yaml
@@ -83,6 +83,7 @@ persistence:
 metrics:
   enabled: false
   prometheusOperator: false
+  extraRuleLabels: null
   image:
     registry: docker.io
     repository: sscaling/jmx-prometheus-exporter


### PR DESCRIPTION
#### What this PR does / why we need it:

* Allow specifying extra labels on PrometheusRules (e.g. to be picked up by specific ServiceMonitors)

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] Chart Version bumped
- [x] I have run `make docs`
- [x] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] PR contains the label that identifies the chart, e.g. `chart/<chart-name>`
- [x] PR contains the label that identifies the type of change, which is one of
      [ `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency` ]
