### PR TITLE
Add option to expose a filterproxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ helm repo add appuio https://charts.appuio.ch
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/data-cube-curation-0.3.1/total)](https://github.com/appuio/charts/releases/tag/data-cube-curation-0.3.1) | [data-cube-curation](appuio/data-cube-curation/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/exoip-1.0.4/total)](https://github.com/appuio/charts/releases/tag/exoip-1.0.4) | [exoip](appuio/exoip/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/generic-0.1.2/total)](https://github.com/appuio/charts/releases/tag/generic-0.1.2) | [generic](appuio/generic/README.md) |
-| [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/haproxy-2.1.0/total)](https://github.com/appuio/charts/releases/tag/haproxy-2.1.0) | [haproxy](appuio/haproxy/README.md) |
+| [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/haproxy-2.2.0/total)](https://github.com/appuio/charts/releases/tag/haproxy-2.2.0) | [haproxy](appuio/haproxy/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/mariadb-galera-1.2.4/total)](https://github.com/appuio/charts/releases/tag/mariadb-galera-1.2.4) | [mariadb-galera](appuio/mariadb-galera/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/maxscale-1.1.2/total)](https://github.com/appuio/charts/releases/tag/maxscale-1.1.2) | [maxscale](appuio/maxscale/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/metrics-server-2.12.1/total)](https://github.com/appuio/charts/releases/tag/metrics-server-2.12.1) | [metrics-server](appuio/metrics-server/README.md) |

--- a/appuio/haproxy/Chart.yaml
+++ b/appuio/haproxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 2.6.1
 description: A Helm chart for HAProxy which can be customized by a config map.
 name: haproxy
-version: 2.1.0
+version: 2.2.0
 maintainers:
   - name: APPUiO Team
     email: info@appuio.ch

--- a/appuio/haproxy/README.gotmpl.md
+++ b/appuio/haproxy/README.gotmpl.md
@@ -138,19 +138,33 @@ Set `haproxy.config` to `redisk8s` to use the Redis configuration with DNS servi
 
 | Parameter              | Description            | Default
 |---                     | ---                    | ---
-| `filterproxy.enabled` | Enables exposing an [exporter-filterproxy](https://github.com/vshn/exporter-filterproxy) that will be filtered based on the namespace | `false`
-| `filterproxy.url` | The URL of the exporter-filterproxy to expose | `""`
+| `haproxy.filterproxy.enabled` | Enables exposing an [exporter-filterproxy](https://github.com/vshn/exporter-filterproxy) that will be filtered based on the namespace | `false`
+| `haproxy.filterproxy.url` | The URL of the exporter-filterproxy to expose | `""`
 
 ## Galera and Redis metrics
 
 By setting the `haproxy.galerak8s.metrics.enabled` or `haproxy.redisk8s.metrics.enabled` parameters, you can expose the metrics of the backend pods.
 
-For Galera the endpoints are:
+For Galera the endpoints are either:
 * `<haproxy_service_ip>:9090/mariadb/0`
 * `<haproxy_service_ip>:9090/mariadb/1`
 * `...`
 
-For Redis the endpoints are:
+Or:
+* `mariadb-0.example.com:9090/metrics`
+* `mariadb-1.example.com:9090/metrics`
+* `...`
+
+When `mariadb-<nr>.example.com` resolves to the haproxy service IP.
+
+For Redis the endpoints are either:
 * `<haproxy_service_ip>:9090/redis/0`
 * `<haproxy_service_ip>:9090/redis/1`
 * `...`
+
+Or:
+* `redis-0.example.com:9090/metrics`
+* `redis-1.example.com:9090/metrics`
+* `...`
+
+When `redis-<nr>.example.com` resolves to the haproxy service IP.

--- a/appuio/haproxy/README.gotmpl.md
+++ b/appuio/haproxy/README.gotmpl.md
@@ -134,6 +134,12 @@ Set `haproxy.config` to `redisk8s` to use the Redis configuration with DNS servi
 | `haproxy.redisk8s.metrics.enabled`| If the metric endpoint of the Redis backends should be exposed in haproxy | `false`
 | `haproxy.redisk8s.metrics.exposeLoadbalancer`| If the metric endpoint of the Redis backends should be exposed in the haproxy service | `true`
 
+### filterproxy
+
+| Parameter              | Description            | Default
+|---                     | ---                    | ---
+| `filterproxy.enabled` | Enables exposing an [exporter-filterproxy](https://github.com/vshn/exporter-filterproxy) that will be filtered based on the namespace | `false`
+| `filterproxy.url` | The URL of the exporter-filterproxy to expose | `""`
 
 ## Galera and Redis metrics
 

--- a/appuio/haproxy/README.gotmpl.md
+++ b/appuio/haproxy/README.gotmpl.md
@@ -146,11 +146,11 @@ Set `haproxy.config` to `redisk8s` to use the Redis configuration with DNS servi
 By setting the `haproxy.galerak8s.metrics.enabled` or `haproxy.redisk8s.metrics.enabled` parameters, you can expose the metrics of the backend pods.
 
 For Galera the endpoints are:
-* `<haproxy_service_ip>:9090/metrics/mariadb-0/metrics`
-* `<haproxy_service_ip>:9090/metrics/mariadb-1/metrics`
+* `<haproxy_service_ip>:9090/mariadb/0`
+* `<haproxy_service_ip>:9090/mariadb/1`
 * `...`
 
 For Redis the endpoints are:
-* `<haproxy_service_ip>:9090/metrics/redis-0/metrics`
-* `<haproxy_service_ip>:9090/metrics/redis-1/metrics`
+* `<haproxy_service_ip>:9090/redis/0`
+* `<haproxy_service_ip>:9090/redis/1`
 * `...`

--- a/appuio/haproxy/README.md
+++ b/appuio/haproxy/README.md
@@ -148,22 +148,36 @@ Set `haproxy.config` to `redisk8s` to use the Redis configuration with DNS servi
 
 | Parameter              | Description            | Default
 |---                     | ---                    | ---
-| `filterproxy.enabled` | Enables exposing an [exporter-filterproxy](https://github.com/vshn/exporter-filterproxy) that will be filtered based on the namespace | `false`
-| `filterproxy.url` | The URL of the exporter-filterproxy to expose | `""`
+| `haproxy.filterproxy.enabled` | Enables exposing an [exporter-filterproxy](https://github.com/vshn/exporter-filterproxy) that will be filtered based on the namespace | `false`
+| `haproxy.filterproxy.url` | The URL of the exporter-filterproxy to expose | `""`
 
 ## Galera and Redis metrics
 
 By setting the `haproxy.galerak8s.metrics.enabled` or `haproxy.redisk8s.metrics.enabled` parameters, you can expose the metrics of the backend pods.
 
-For Galera the endpoints are:
+For Galera the endpoints are either:
 * `<haproxy_service_ip>:9090/mariadb/0`
 * `<haproxy_service_ip>:9090/mariadb/1`
 * `...`
 
-For Redis the endpoints are:
+Or:
+* `mariadb-0.example.com:9090/metrics`
+* `mariadb-1.example.com:9090/metrics`
+* `...`
+
+When `mariadb-<nr>.example.com` resolves to the haproxy service IP.
+
+For Redis the endpoints are either:
 * `<haproxy_service_ip>:9090/redis/0`
 * `<haproxy_service_ip>:9090/redis/1`
 * `...`
+
+Or:
+* `redis-0.example.com:9090/metrics`
+* `redis-1.example.com:9090/metrics`
+* `...`
+
+When `redis-<nr>.example.com` resolves to the haproxy service IP.
 
 <!---
 Common/Useful Link references from values.yaml

--- a/appuio/haproxy/README.md
+++ b/appuio/haproxy/README.md
@@ -1,6 +1,6 @@
 # haproxy
 
-![Version: 2.1.0](https://img.shields.io/badge/Version-2.1.0-informational?style=flat-square) ![AppVersion: 2.6.1](https://img.shields.io/badge/AppVersion-2.6.1-informational?style=flat-square)
+![Version: 2.2.0](https://img.shields.io/badge/Version-2.2.0-informational?style=flat-square) ![AppVersion: 2.6.1](https://img.shields.io/badge/AppVersion-2.6.1-informational?style=flat-square)
 
 A Helm chart for HAProxy which can be customized by a config map.
 
@@ -143,6 +143,13 @@ Set `haproxy.config` to `redisk8s` to use the Redis configuration with DNS servi
 | `haproxy.redisk8s.port` | Port of the Galera node | `6379`
 | `haproxy.redisk8s.metrics.enabled`| If the metric endpoint of the Redis backends should be exposed in haproxy | `false`
 | `haproxy.redisk8s.metrics.exposeLoadbalancer`| If the metric endpoint of the Redis backends should be exposed in the haproxy service | `true`
+
+### filterproxy
+
+| Parameter              | Description            | Default
+|---                     | ---                    | ---
+| `filterproxy.enabled` | Enables exposing an [exporter-filterproxy](https://github.com/vshn/exporter-filterproxy) that will be filtered based on the namespace | `false`
+| `filterproxy.url` | The URL of the exporter-filterproxy to expose | `""`
 
 ## Galera and Redis metrics
 

--- a/appuio/haproxy/README.md
+++ b/appuio/haproxy/README.md
@@ -156,13 +156,13 @@ Set `haproxy.config` to `redisk8s` to use the Redis configuration with DNS servi
 By setting the `haproxy.galerak8s.metrics.enabled` or `haproxy.redisk8s.metrics.enabled` parameters, you can expose the metrics of the backend pods.
 
 For Galera the endpoints are:
-* `<haproxy_service_ip>:9090/metrics/mariadb-0/metrics`
-* `<haproxy_service_ip>:9090/metrics/mariadb-1/metrics`
+* `<haproxy_service_ip>:9090/mariadb/0`
+* `<haproxy_service_ip>:9090/mariadb/1`
 * `...`
 
 For Redis the endpoints are:
-* `<haproxy_service_ip>:9090/metrics/redis-0/metrics`
-* `<haproxy_service_ip>:9090/metrics/redis-1/metrics`
+* `<haproxy_service_ip>:9090/redis/0`
+* `<haproxy_service_ip>:9090/redis/1`
 * `...`
 
 <!---

--- a/appuio/haproxy/templates/_helpers.tpl
+++ b/appuio/haproxy/templates/_helpers.tpl
@@ -97,6 +97,9 @@ frontend galeraMetrics
   {{- range $i, $e := until (.Values.haproxy.galerak8s.nodeCount |int) }}
   use_backend galera-node-{{$i}} if { hdr_sub(host) -i mariadb-{{$i}} }
   {{- end }}
+  {{- range $i, $e := until (.Values.haproxy.galerak8s.nodeCount |int) }}
+  use_backend galera-node-metrics-{{$i}} if { path_beg /mariadb/{{$i}} }
+  {{- end }}
   {{- if .Values.haproxy.filterproxy.enabled }}
   use_backend filterproxy
   {{- end }}
@@ -105,6 +108,12 @@ frontend galeraMetrics
 {{ range $i, $e := until (.Values.haproxy.galerak8s.nodeCount |int) }}
 backend galera-node-{{$i}}
   mode http
+  server node-{{$i}} mariadb-{{$i}}.mariadb.{{ $namespace }}.svc.cluster.local:9104 init-addr none check resolvers mydns
+{{- end }}
+{{ range $i, $e := until (.Values.haproxy.galerak8s.nodeCount |int) }}
+backend galera-node-metrics-{{$i}}
+  mode http
+  http-request set-path /metrics
   server node-{{$i}} mariadb-{{$i}}.mariadb.{{ $namespace }}.svc.cluster.local:9104 init-addr none check resolvers mydns
 {{- end }}
 {{- if .Values.haproxy.filterproxy.enabled }}
@@ -128,6 +137,9 @@ frontend redisMetrics
   {{- range $i, $e := until (.Values.haproxy.redisk8s.nodeCount |int) }}
   use_backend redis-node-{{$i}} if { hdr_sub(host) -i redis-{{$i}} }
   {{- end }}
+  {{- range $i, $e := until (.Values.haproxy.redisk8s.nodeCount |int) }}
+  use_backend redis-node-metrics-{{$i}} if { path_beg /redis/{{$i}} }
+  {{- end }}
   {{- if .Values.haproxy.filterproxy.enabled }}
   use_backend filterproxy
   {{- end }}
@@ -136,6 +148,12 @@ frontend redisMetrics
 {{ range $i, $e := until (.Values.haproxy.redisk8s.nodeCount |int) }}
 backend redis-node-{{$i}}
   mode http
+  server node-{{$i}} redis-node-{{$i}}.redis-headless.{{ $namespace }}.svc.cluster.local:9121 init-addr none check resolvers mydns
+{{- end }}
+{{ range $i, $e := until (.Values.haproxy.galerak8s.nodeCount |int) }}
+backend redis-node-metrics-{{$i}}
+  mode http
+  http-request set-path /metrics
   server node-{{$i}} redis-node-{{$i}}.redis-headless.{{ $namespace }}.svc.cluster.local:9121 init-addr none check resolvers mydns
 {{- end }}
 {{- if .Values.haproxy.filterproxy.enabled }}

--- a/appuio/haproxy/templates/_helpers.tpl
+++ b/appuio/haproxy/templates/_helpers.tpl
@@ -97,12 +97,21 @@ frontend galeraMetrics
   {{- range $i, $e := until (.Values.haproxy.galerak8s.nodeCount |int) }}
   use_backend galera-node-{{$i}} if { hdr_sub(host) -i mariadb-{{$i}} }
   {{- end }}
+  {{- if .Values.haproxy.filterproxy.enabled }}
+  use_backend filterproxy
+  {{- end }}
 
 {{- $namespace := .Release.Namespace -}}
 {{ range $i, $e := until (.Values.haproxy.galerak8s.nodeCount |int) }}
 backend galera-node-{{$i}}
   mode http
   server node-{{$i}} mariadb-{{$i}}.mariadb.{{ $namespace }}.svc.cluster.local:9104 init-addr none check resolvers mydns
+{{- end }}
+{{- if .Values.haproxy.filterproxy.enabled }}
+backend filterproxy
+  mode http
+  http-request set-query namespace={{ $namespace }}
+  server filter {{ .Values.haproxy.filterproxy.url }}
 {{- end }}
 {{- end }}
 {{- end -}}
@@ -119,12 +128,21 @@ frontend redisMetrics
   {{- range $i, $e := until (.Values.haproxy.redisk8s.nodeCount |int) }}
   use_backend redis-node-{{$i}} if { hdr_sub(host) -i redis-{{$i}} }
   {{- end }}
+  {{- if .Values.haproxy.filterproxy.enabled }}
+  use_backend filterproxy
+  {{- end }}
 
 {{- $namespace := .Release.Namespace -}}
 {{ range $i, $e := until (.Values.haproxy.redisk8s.nodeCount |int) }}
 backend redis-node-{{$i}}
   mode http
   server node-{{$i}} redis-node-{{$i}}.redis-headless.{{ $namespace }}.svc.cluster.local:9121 init-addr none check resolvers mydns
+{{- end }}
+{{- if .Values.haproxy.filterproxy.enabled }}
+backend filterproxy
+  mode http
+  http-request set-query namespace={{ $namespace }}
+  server filter {{ .Values.haproxy.filterproxy.url }}
 {{- end }}
 {{- end }}
 {{- end -}}

--- a/appuio/haproxy/values.yaml
+++ b/appuio/haproxy/values.yaml
@@ -106,6 +106,12 @@ haproxy:
       enabled: false
       exposeLoadbalancer: true
 
+  filterproxy:
+    # Enables exposing an [exporter-filterproxy](https://github.com/vshn/exporter-filterproxy) that will be filtered using the namspace
+    enabled: false
+    # The URL of the exporter-filterproxy to expose
+    url: ""
+
 metrics:
   enabled: true
 


### PR DESCRIPTION
With this we can forward a view of the https://github.com/vshn/exporter-filterproxy. Is used to provide the metrics related to the namespace.

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] Chart Version bumped
- [x] I have run `make docs`
- [x] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] PR contains the label that identifies the chart, e.g. `chart/<chart-name>`
- [x] PR contains the label that identifies the type of change, which is one of
      [ `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency` ]
