### PR TITLE
[stardog] Fix ZooKeeper anti-affinity rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ helm repo add appuio https://charts.appuio.ch
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/secret-1.1.0/total)](https://github.com/appuio/charts/releases/tag/secret-1.1.0) | [secret](appuio/secret/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/signalilo-0.12.0/total)](https://github.com/appuio/charts/releases/tag/signalilo-0.12.0) | [signalilo](appuio/signalilo/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/snappass-0.2.15/total)](https://github.com/appuio/charts/releases/tag/snappass-0.2.15) | [snappass](appuio/snappass/README.md) |
-| [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/stardog-0.15.1/total)](https://github.com/appuio/charts/releases/tag/stardog-0.15.1) | [stardog](appuio/stardog/README.md) |
+| [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/stardog-0.16.0/total)](https://github.com/appuio/charts/releases/tag/stardog-0.16.0) | [stardog](appuio/stardog/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/stardog-userrole-operator-0.1.1/total)](https://github.com/appuio/charts/releases/tag/stardog-userrole-operator-0.1.1) | [stardog-userrole-operator](appuio/stardog-userrole-operator/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/trifid-1.2.3/total)](https://github.com/appuio/charts/releases/tag/trifid-1.2.3) | [trifid](appuio/trifid/README.md) |
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ helm repo add appuio https://charts.appuio.ch
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/secret-1.1.0/total)](https://github.com/appuio/charts/releases/tag/secret-1.1.0) | [secret](appuio/secret/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/signalilo-0.12.0/total)](https://github.com/appuio/charts/releases/tag/signalilo-0.12.0) | [signalilo](appuio/signalilo/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/snappass-0.2.15/total)](https://github.com/appuio/charts/releases/tag/snappass-0.2.15) | [snappass](appuio/snappass/README.md) |
-| [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/stardog-0.16.0/total)](https://github.com/appuio/charts/releases/tag/stardog-0.16.0) | [stardog](appuio/stardog/README.md) |
+| [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/stardog-0.16.1/total)](https://github.com/appuio/charts/releases/tag/stardog-0.16.1) | [stardog](appuio/stardog/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/stardog-userrole-operator-0.1.1/total)](https://github.com/appuio/charts/releases/tag/stardog-userrole-operator-0.1.1) | [stardog-userrole-operator](appuio/stardog-userrole-operator/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/trifid-1.2.3/total)](https://github.com/appuio/charts/releases/tag/trifid-1.2.3) | [trifid](appuio/trifid/README.md) |
 

--- a/appuio/stardog/Chart.yaml
+++ b/appuio/stardog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: stardog
-version: 0.16.0
+version: 0.16.1
 appVersion: 8.2.2
 description: Stardog is the world’s leading knowledge graph platform for the enterprise. Stardog makes it fast and easy to turn enterprise data into knowledge.
 home: "https://www.stardog.com/"

--- a/appuio/stardog/Chart.yaml
+++ b/appuio/stardog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: stardog
-version: 0.15.1
+version: 0.16.0
 appVersion: 8.2.2
 description: Stardog is the world’s leading knowledge graph platform for the enterprise. Stardog makes it fast and easy to turn enterprise data into knowledge.
 home: "https://www.stardog.com/"

--- a/appuio/stardog/README.md
+++ b/appuio/stardog/README.md
@@ -1,6 +1,6 @@
 # stardog
 
-![Version: 0.15.1](https://img.shields.io/badge/Version-0.15.1-informational?style=flat-square) ![AppVersion: 8.2.2](https://img.shields.io/badge/AppVersion-8.2.2-informational?style=flat-square)
+![Version: 0.16.0](https://img.shields.io/badge/Version-0.16.0-informational?style=flat-square) ![AppVersion: 8.2.2](https://img.shields.io/badge/AppVersion-8.2.2-informational?style=flat-square)
 
 Stardog is the world’s leading knowledge graph platform for the enterprise. Stardog makes it fast and easy to turn enterprise data into knowledge.
 

--- a/appuio/stardog/README.md
+++ b/appuio/stardog/README.md
@@ -1,6 +1,6 @@
 # stardog
 
-![Version: 0.16.0](https://img.shields.io/badge/Version-0.16.0-informational?style=flat-square) ![AppVersion: 8.2.2](https://img.shields.io/badge/AppVersion-8.2.2-informational?style=flat-square)
+![Version: 0.16.1](https://img.shields.io/badge/Version-0.16.1-informational?style=flat-square) ![AppVersion: 8.2.2](https://img.shields.io/badge/AppVersion-8.2.2-informational?style=flat-square)
 
 Stardog is the world’s leading knowledge graph platform for the enterprise. Stardog makes it fast and easy to turn enterprise data into knowledge.
 

--- a/appuio/stardog/templates/ingress.yaml
+++ b/appuio/stardog/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- $ingress := .Values.ingress -}}
 {{- if $ingress.enabled -}}
 {{- $fullName := include "stardog.fullname" . -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -30,7 +30,10 @@ spec:
       http:
         paths:
           - path: /
+            pathType: Prefix
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: stardog
+              service:
+                name: {{ $fullName }}
+                port:
+                  name: stardog
 {{- end }}

--- a/appuio/stardog/values.yaml
+++ b/appuio/stardog/values.yaml
@@ -121,20 +121,4 @@ zookeeper:
     enabled: true
     serviceMonitor:
       enabled: true
-  affinity:
-    podAntiAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-        - labelSelector:
-            matchExpressions:
-              - key: app.kubernetes.io/name
-                operator: In
-                values:
-                - stardog
-          topologyKey: kubernetes.io/hostname
-        - labelSelector:
-            matchExpressions:
-              - key: app.kubernetes.io/component
-                operator: In
-                values:
-                - zookeeper
-          topologyKey: kubernetes.io/hostname
+  podAntiAffinityPreset: hard


### PR DESCRIPTION
#### What this PR does / why we need it:

* Fixes ZooKeeper anti-affinity rules that ensured anti-affinity to Stardog pods

#### Checklist
- [x] Chart Version bumped
- [x] I have run `make docs`
- [x] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] PR contains the label that identifies the chart, e.g. `chart/<chart-name>`
- [x] PR contains the label that identifies the type of change, which is one of
      [ `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency` ]
