### PR TITLE
[stardog] Update JMX exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ helm repo add appuio https://charts.appuio.ch
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/secret-1.1.0/total)](https://github.com/appuio/charts/releases/tag/secret-1.1.0) | [secret](appuio/secret/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/signalilo-0.12.0/total)](https://github.com/appuio/charts/releases/tag/signalilo-0.12.0) | [signalilo](appuio/signalilo/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/snappass-0.2.15/total)](https://github.com/appuio/charts/releases/tag/snappass-0.2.15) | [snappass](appuio/snappass/README.md) |
-| [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/stardog-0.16.2/total)](https://github.com/appuio/charts/releases/tag/stardog-0.16.2) | [stardog](appuio/stardog/README.md) |
+| [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/stardog-0.17.0/total)](https://github.com/appuio/charts/releases/tag/stardog-0.17.0) | [stardog](appuio/stardog/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/stardog-userrole-operator-0.1.1/total)](https://github.com/appuio/charts/releases/tag/stardog-userrole-operator-0.1.1) | [stardog-userrole-operator](appuio/stardog-userrole-operator/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/trifid-1.2.3/total)](https://github.com/appuio/charts/releases/tag/trifid-1.2.3) | [trifid](appuio/trifid/README.md) |
 

--- a/appuio/stardog/Chart.yaml
+++ b/appuio/stardog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: stardog
-version: 0.16.2
+version: 0.17.0
 appVersion: 8.2.2
 description: Stardog is the world’s leading knowledge graph platform for the enterprise. Stardog makes it fast and easy to turn enterprise data into knowledge.
 home: "https://www.stardog.com/"

--- a/appuio/stardog/README.md
+++ b/appuio/stardog/README.md
@@ -1,6 +1,6 @@
 # stardog
 
-![Version: 0.16.2](https://img.shields.io/badge/Version-0.16.2-informational?style=flat-square) ![AppVersion: 8.2.2](https://img.shields.io/badge/AppVersion-8.2.2-informational?style=flat-square)
+![Version: 0.17.0](https://img.shields.io/badge/Version-0.17.0-informational?style=flat-square) ![AppVersion: 8.2.2](https://img.shields.io/badge/AppVersion-8.2.2-informational?style=flat-square)
 
 Stardog is the world’s leading knowledge graph platform for the enterprise. Stardog makes it fast and easy to turn enterprise data into knowledge.
 

--- a/appuio/stardog/templates/statefulset.yaml
+++ b/appuio/stardog/templates/statefulset.yaml
@@ -111,11 +111,9 @@ spec:
         - name: jmx-exporter
           image: {{ .Values.metrics.image.registry }}/{{ .Values.metrics.image.repository }}:{{ .Values.metrics.image.tag }}
           imagePullPolicy: {{ .Values.metrics.image.pullPolicy }}
-          env:
-            - name: CONFIG_YML
-              value: /etc/jmx_exporter/jmx-exporter.yaml
-            - name: JVM_OPTS
-              value: -XX:MaxRAM=100M
+          args:
+            - "5556"
+            - "/etc/jmx_exporter/jmx-exporter.yaml"
           ports:
             - name: metrics
               containerPort: 5556
@@ -133,12 +131,7 @@ spec:
               port: metrics
             initialDelaySeconds: 15
           resources:
-            requests:
-              memory: 128Mi
-              cpu: 500m
-            limits:
-              memory: 128Mi
-              cpu: 500m
+            {{- toYaml .Values.metrics.resources | nindent 12 }}
       {{- end }}
       terminationGracePeriodSeconds: 600
       securityContext: {{ .Values.stardog.securityContext | toYaml | nindent 8 }}

--- a/appuio/stardog/values.yaml
+++ b/appuio/stardog/values.yaml
@@ -89,9 +89,16 @@ metrics:
     extraLabels: null
   image:
     registry: docker.io
-    repository: sscaling/jmx-prometheus-exporter
-    tag: 0.12.0
+    repository: bitnami/jmx-exporter
+    tag: 0.18.0
     pullPolicy: IfNotPresent
+  resources:
+    requests:
+      memory: 128Mi
+      cpu: 500m
+    limits:
+      memory: 128Mi
+      cpu: 1000m
 
 resources: {}
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Updates the JMX exporter

The latest version no longer requires explicit XX:MaxRAM settings.

Also making the resources for it configurable in a backwards-compatible way.

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] Chart Version bumped
- [x] I have run `make docs`
- [x] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] PR contains the label that identifies the chart, e.g. `chart/<chart-name>`
- [x] PR contains the label that identifies the type of change, which is one of
      [ `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency` ]
