### PR TITLE
Remove @anothertobi from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -9,7 +9,7 @@
 /appuio/generic           @appuio/tarazed
 /appuio/openshift-route   @appuio/tarazed
 /appuio/secret            @appuio/tarazed
-/appuio/haproxy           @appuio/tarazed @anothertobi
+/appuio/haproxy           @appuio/tarazed
 
 # Other charts
 /appuio/signalilo         @simu


### PR DESCRIPTION
#### What this PR does / why we need it:

* Updates CODEOWNERS

#### Checklist
- [ ] PR contains the label that identifies the type of change, which is one of
      [ `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency` ]
