### PR TITLE
[Trifid] Add `extraEnv` support

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ helm repo add appuio https://charts.appuio.ch
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/snappass-1.0.0/total)](https://github.com/appuio/charts/releases/tag/snappass-1.0.0) | [snappass](appuio/snappass/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/stardog-0.19.0/total)](https://github.com/appuio/charts/releases/tag/stardog-0.19.0) | [stardog](appuio/stardog/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/stardog-userrole-operator-0.2.3/total)](https://github.com/appuio/charts/releases/tag/stardog-userrole-operator-0.2.3) | [stardog-userrole-operator](appuio/stardog-userrole-operator/README.md) |
-| [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/trifid-2.0.1/total)](https://github.com/appuio/charts/releases/tag/trifid-2.0.1) | [trifid](appuio/trifid/README.md) |
+| [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/trifid-2.0.2/total)](https://github.com/appuio/charts/releases/tag/trifid-2.0.2) | [trifid](appuio/trifid/README.md) |
 
 ## Add / Update Charts
 

--- a/appuio/trifid/Chart.yaml
+++ b/appuio/trifid/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: trifid
 description: Trifid provides a lightweight and easy way to access Linked Data URIs via HTTP.
-version: 2.0.1
+version: 2.0.2
 appVersion: 2.3.7
 home: "https://github.com/zazuko/trifid"
 sources:
-- https://github.com/zazuko/trifid
+  - https://github.com/zazuko/trifid

--- a/appuio/trifid/README.md
+++ b/appuio/trifid/README.md
@@ -1,6 +1,6 @@
 # trifid
 
-![Version: 2.0.1](https://img.shields.io/badge/Version-2.0.1-informational?style=flat-square) ![AppVersion: 2.3.7](https://img.shields.io/badge/AppVersion-2.3.7-informational?style=flat-square)
+![Version: 2.0.2](https://img.shields.io/badge/Version-2.0.2-informational?style=flat-square) ![AppVersion: 2.3.7](https://img.shields.io/badge/AppVersion-2.3.7-informational?style=flat-square)
 
 Trifid provides a lightweight and easy way to access Linked Data URIs via HTTP.
 

--- a/appuio/trifid/templates/deployment.yaml
+++ b/appuio/trifid/templates/deployment.yaml
@@ -41,6 +41,10 @@ spec:
               secretKeyRef:
                 name: {{ if $endpoint.secretName }}{{ $endpoint.secretName }}{{ else }}{{ include "trifid.fullname" . }}{{ end }}
                 key: password
+          {{- range $key, $value := .Values.extraEnv }}
+          - name: {{ $key }}
+            value: {{ $value }}
+          {{- end }}
           ports:
             - name: http
               containerPort: 8080

--- a/appuio/trifid/values.yaml
+++ b/appuio/trifid/values.yaml
@@ -31,7 +31,7 @@ podSecurityContext:
 securityContext:
   capabilities:
     drop:
-    - ALL
+      - ALL
   runAsNonRoot: true
   runAsUser: 1000
   readOnlyRootFilesystem: true
@@ -46,7 +46,8 @@ service:
 
 ingress:
   enabled: false
-  annotations: {}
+  annotations:
+    {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   hosts:
@@ -68,3 +69,7 @@ resources:
 nodeSelector: {}
 
 tolerations: []
+
+extraEnv:
+  {}
+  # VARIABLE_NAME: value


### PR DESCRIPTION
<!--
Thank you for contributing to appuio/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

-->

#### What this PR does / why we need it:

* Short summary

This PR adds support of the `extraEnv` in values for the Trifid chart.

This is useful if we want to pass additional environment variables to Trifid.

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] Chart Version bumped
- [x] I have run `make docs` ; it's doing nothing, and it's saying "make: Nothing to be done for `docs'."
- [x] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] PR contains the label that identifies the chart, e.g. `chart/<chart-name>`
- [x] PR contains the label that identifies the type of change, which is one of
      [ `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency` ]
