### PR TITLE
Add preStop hook for cleaner termination of Stardog server

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ helm repo add appuio https://charts.appuio.ch
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/secret-1.1.0/total)](https://github.com/appuio/charts/releases/tag/secret-1.1.0) | [secret](appuio/secret/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/signalilo-0.12.1/total)](https://github.com/appuio/charts/releases/tag/signalilo-0.12.1) | [signalilo](appuio/signalilo/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/snappass-1.0.0/total)](https://github.com/appuio/charts/releases/tag/snappass-1.0.0) | [snappass](appuio/snappass/README.md) |
-| [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/stardog-0.19.0/total)](https://github.com/appuio/charts/releases/tag/stardog-0.19.0) | [stardog](appuio/stardog/README.md) |
+| [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/stardog-0.20.0/total)](https://github.com/appuio/charts/releases/tag/stardog-0.20.0) | [stardog](appuio/stardog/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/stardog-userrole-operator-0.2.3/total)](https://github.com/appuio/charts/releases/tag/stardog-userrole-operator-0.2.3) | [stardog-userrole-operator](appuio/stardog-userrole-operator/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/trifid-2.0.1/total)](https://github.com/appuio/charts/releases/tag/trifid-2.0.1) | [trifid](appuio/trifid/README.md) |
 

--- a/appuio/stardog/Chart.yaml
+++ b/appuio/stardog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: stardog
-version: 0.19.0
+version: 0.20.0
 appVersion: 9.1.0
 description: Stardog is the world’s leading knowledge graph platform for the enterprise. Stardog makes it fast and easy to turn enterprise data into knowledge.
 home: "https://www.stardog.com/"

--- a/appuio/stardog/README.md
+++ b/appuio/stardog/README.md
@@ -1,6 +1,6 @@
 # stardog
 
-![Version: 0.19.0](https://img.shields.io/badge/Version-0.19.0-informational?style=flat-square) ![AppVersion: 9.1.0](https://img.shields.io/badge/AppVersion-9.1.0-informational?style=flat-square)
+![Version: 0.20.0](https://img.shields.io/badge/Version-0.20.0-informational?style=flat-square) ![AppVersion: 9.1.0](https://img.shields.io/badge/AppVersion-9.1.0-informational?style=flat-square)
 
 Stardog is the world’s leading knowledge graph platform for the enterprise. Stardog makes it fast and easy to turn enterprise data into knowledge.
 

--- a/appuio/stardog/templates/statefulset.yaml
+++ b/appuio/stardog/templates/statefulset.yaml
@@ -60,6 +60,14 @@ spec:
               set -e
               sed "s|\$ZOOKEEPER_USERNAME|$ZOOKEEPER_USERNAME|g; s|\$ZOOKEEPER_PASSWORD|$ZOOKEEPER_PASSWORD|g" ${STARDOG_HOME}/stardog.properties.tpl > ${STARDOG_HOME}/stardog.properties
               /opt/stardog/bin/stardog-admin server start --foreground
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                - /bin/bash
+                - -c
+                - |
+                  /opt/stardog/bin/stardog-admin server stop -u admin -p ${STARDOG_ADMIN_PW}
           env:
             {{- if and .Values.zookeeper.enabled .Values.zookeeper.auth.enabled }}
             - name: ZOOKEEPER_USERNAME
@@ -74,6 +82,11 @@ spec:
               value: "{{ .Values.stardog.javaArgs }} -XX:ParallelGCThreads=2 -Dstardog.license.location=/run/secrets/stardog/stardog-license-key.bin"
             - name: STARDOG_HOME
               value: /var/opt/stardog/data/
+            - name: STARDOG_ADMIN_PW
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "stardog.fullname" $ }}-user-passwords
+                  key: admin
           ports:
             - name: stardog
               containerPort: 5820


### PR DESCRIPTION
<!--
Thank you for contributing to appuio/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

-->

#### What this PR does / why we need it:

* Terminate Stardog explicitly using a preStop hook

Stardog stopped terminating cleanly starting with version 9 and seemingly only responds to SIGKILL after `terminationGracePeriodSeconds`. This PR copies [an idea](https://github.com/stardog-union/helm-charts/blob/develop/charts/stardog/templates/statefulset.yaml#L156C1-L163C108) from Stardog's developers where they use a preStop hook instead of relying on SIGTERM.

Without this, any upgrade will require a minimum of 10 minutes per instance, likely more since database reindexing can easily take 20 minutes on a data set of half a billion triples.

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] Chart Version bumped
- [x] I have run `make docs`
- [x] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] PR contains the label that identifies the chart, e.g. `chart/<chart-name>`
- [x] PR contains the label that identifies the type of change, which is one of
      [ `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency` ]
