### PR TITLE
Adding https checks for HAproxy and Galera

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ helm repo add appuio https://charts.appuio.ch
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/data-cube-curation-0.3.1/total)](https://github.com/appuio/charts/releases/tag/data-cube-curation-0.3.1) | [data-cube-curation](appuio/data-cube-curation/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/exoip-1.0.4/total)](https://github.com/appuio/charts/releases/tag/exoip-1.0.4) | [exoip](appuio/exoip/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/generic-0.1.2/total)](https://github.com/appuio/charts/releases/tag/generic-0.1.2) | [generic](appuio/generic/README.md) |
-| [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/haproxy-2.3.2/total)](https://github.com/appuio/charts/releases/tag/haproxy-2.3.2) | [haproxy](appuio/haproxy/README.md) |
+| [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/haproxy-2.4.0/total)](https://github.com/appuio/charts/releases/tag/haproxy-2.4.0) | [haproxy](appuio/haproxy/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/mariadb-galera-1.2.4/total)](https://github.com/appuio/charts/releases/tag/mariadb-galera-1.2.4) | [mariadb-galera](appuio/mariadb-galera/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/maxscale-2.0.1/total)](https://github.com/appuio/charts/releases/tag/maxscale-2.0.1) | [maxscale](appuio/maxscale/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/metrics-server-2.12.1/total)](https://github.com/appuio/charts/releases/tag/metrics-server-2.12.1) | [metrics-server](appuio/metrics-server/README.md) |

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ helm repo add appuio https://charts.appuio.ch
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/data-cube-curation-0.3.1/total)](https://github.com/appuio/charts/releases/tag/data-cube-curation-0.3.1) | [data-cube-curation](appuio/data-cube-curation/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/exoip-1.0.4/total)](https://github.com/appuio/charts/releases/tag/exoip-1.0.4) | [exoip](appuio/exoip/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/generic-0.1.2/total)](https://github.com/appuio/charts/releases/tag/generic-0.1.2) | [generic](appuio/generic/README.md) |
-| [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/haproxy-2.3.1/total)](https://github.com/appuio/charts/releases/tag/haproxy-2.3.1) | [haproxy](appuio/haproxy/README.md) |
+| [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/haproxy-2.3.2/total)](https://github.com/appuio/charts/releases/tag/haproxy-2.3.2) | [haproxy](appuio/haproxy/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/mariadb-galera-1.2.4/total)](https://github.com/appuio/charts/releases/tag/mariadb-galera-1.2.4) | [mariadb-galera](appuio/mariadb-galera/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/maxscale-2.0.1/total)](https://github.com/appuio/charts/releases/tag/maxscale-2.0.1) | [maxscale](appuio/maxscale/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/metrics-server-2.12.1/total)](https://github.com/appuio/charts/releases/tag/metrics-server-2.12.1) | [metrics-server](appuio/metrics-server/README.md) |

--- a/appuio/haproxy/Chart.yaml
+++ b/appuio/haproxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 2.7.3
 description: A Helm chart for HAProxy which can be customized by a config map.
 name: haproxy
-version: 2.3.1
+version: 2.3.2
 maintainers:
   - name: APPUiO Team
     email: info@appuio.ch

--- a/appuio/haproxy/Chart.yaml
+++ b/appuio/haproxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 2.7.3
 description: A Helm chart for HAProxy which can be customized by a config map.
 name: haproxy
-version: 2.3.2
+version: 2.4.0
 maintainers:
   - name: APPUiO Team
     email: info@appuio.ch

--- a/appuio/haproxy/Dockerfile
+++ b/appuio/haproxy/Dockerfile
@@ -1,4 +1,4 @@
-from haproxytech/haproxy-debian:2.7.3
+from haproxytech/haproxy-debian:2.8.3
 
 RUN curl -o mysql.deb https://dev.mysql.com/get/mysql-apt-config_0.8.26-1_all.deb || exit 1 \
     dpkg -i mysql.deb || exit 1 ; \

--- a/appuio/haproxy/Dockerfile
+++ b/appuio/haproxy/Dockerfile
@@ -1,0 +1,7 @@
+from haproxytech/haproxy-debian:2.7.3
+
+RUN curl -o mysql.deb https://dev.mysql.com/get/mysql-apt-config_0.8.26-1_all.deb || exit 1 \
+    dpkg -i mysql.deb || exit 1 ; \
+    apt-get update || exit 1 ; \
+    apt-get install -y default-mysql-client || exit 1 ; \
+    rm -rf /var/lib/apt/lists/* mysql.deb ;

--- a/appuio/haproxy/README.md
+++ b/appuio/haproxy/README.md
@@ -1,6 +1,6 @@
 # haproxy
 
-![Version: 2.3.2](https://img.shields.io/badge/Version-2.3.2-informational?style=flat-square) ![AppVersion: 2.7.3](https://img.shields.io/badge/AppVersion-2.7.3-informational?style=flat-square)
+![Version: 2.4.0](https://img.shields.io/badge/Version-2.4.0-informational?style=flat-square) ![AppVersion: 2.7.3](https://img.shields.io/badge/AppVersion-2.7.3-informational?style=flat-square)
 
 A Helm chart for HAProxy which can be customized by a config map.
 

--- a/appuio/haproxy/README.md
+++ b/appuio/haproxy/README.md
@@ -1,6 +1,6 @@
 # haproxy
 
-![Version: 2.3.1](https://img.shields.io/badge/Version-2.3.1-informational?style=flat-square) ![AppVersion: 2.7.3](https://img.shields.io/badge/AppVersion-2.7.3-informational?style=flat-square)
+![Version: 2.3.2](https://img.shields.io/badge/Version-2.3.2-informational?style=flat-square) ![AppVersion: 2.7.3](https://img.shields.io/badge/AppVersion-2.7.3-informational?style=flat-square)
 
 A Helm chart for HAProxy which can be customized by a config map.
 

--- a/appuio/haproxy/files/galera-check.sh
+++ b/appuio/haproxy/files/galera-check.sh
@@ -18,7 +18,6 @@ fi
 # sample return -> "WSREP_CLUSTER_STATUS Primary WSREP_CONNECTED ON WSREP_LOCAL_STATE 4 WSREP_READY ON"
 return_val=$(/usr/bin/mysql -h $3 -u root -p"$pass" -e "SELECT VARIABLE_NAME, VARIABLE_VALUE FROM information_schema.global_status WHERE VARIABLE_NAME IN ('wsrep_cluster_status','wsrep_ready','wsrep_local_state','wsrep_connected') ORDER BY VARIABLE_NAME ASC;" -Ns)
 if [ $? -ne 0 ]; then
-  echo Error: Unable to connect to MySQL or query failed
   exit 1
 else
   to_check=$(echo $return_val | cut -d' ' -f2)

--- a/appuio/haproxy/files/galera-check.sh
+++ b/appuio/haproxy/files/galera-check.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+    
+# Run the MySQL query and store the result in a Bash variable
+
+wsrep_ready=`/bin/cat /secrets/mariadb-root-password | /usr/bin/mysql -h $3 -u root -p -e "SELECT VARIABLE_VALUE FROM information_schema.global_status WHERE VARIABLE_NAME = 'wsrep_ready';" -N`
+if [ $? -ne 0 ]; then
+  echo Error: Unable to connect to MySQL or query failed
+  exit 1
+fi
+
+if [ $wsrep_ready != "ON" ]; then
+  echo Error: wsrep_ready is not ON, actual status is: $WSREP_READY
+  exit 1
+fi
+
+exit 0 

--- a/appuio/haproxy/files/galera-check.sh
+++ b/appuio/haproxy/files/galera-check.sh
@@ -24,14 +24,14 @@ else
   to_check=$(echo $return_val | cut -d' ' -f2)
 
   if [ $to_check != "Primary" ]; then
-    echo "Error: WSREP_CLUSTER_STATUS is not 'Primary'"
+    echo "Error: WSREP_CLUSTER_STATUS is not 'Primary' it's: $to_check"
     exit 1
   fi
 
   to_check=$(echo $return_val | cut -d' ' -f4)
 
   if [ $to_check != "ON" ]; then
-    echo "Error: WSREP_CONNECTED is not 'ON'"
+    echo "Error: WSREP_CONNECTED is not 'ON' it's: $to_check"
     exit 1
   fi
 
@@ -44,7 +44,7 @@ else
 
   to_check=$(echo $return_val | cut -d' ' -f8)
   if [ $to_check != "ON" ]; then
-    echo "Error: WSREP_READY is not 'ON'"
+    echo "Error: WSREP_READY is not 'ON' it's: $to_check"
     exit 1
   fi
 fi

--- a/appuio/haproxy/files/galera-check.sh
+++ b/appuio/haproxy/files/galera-check.sh
@@ -1,16 +1,37 @@
 #!/bin/bash
     
-# Run the MySQL query and store the result in a Bash variable
+### This script is used to check the status of the Galera cluster
+### Maintainer: https://github.com/wejdross 
+### It takes hash of checks and expected values as input and returns 0 if all checks are successful, 1 otherwise 
+pass=$(/bin/cat /secrets/mariadb-root-password)
 
-wsrep_ready=`/bin/cat /secrets/mariadb-root-password | /usr/bin/mysql -h $3 -u root -p -e "SELECT VARIABLE_VALUE FROM information_schema.global_status WHERE VARIABLE_NAME = 'wsrep_ready';" -N`
-if [ $? -ne 0 ]; then
-  echo Error: Unable to connect to MySQL or query failed
+if [ -z "$pass" ]; then
+  echo "Error: password is empty, please check mount and permission declared in haproxy deployment"
   exit 1
 fi
 
-if [ $wsrep_ready != "ON" ]; then
-  echo Error: wsrep_ready is not ON, actual status is: $WSREP_READY
-  exit 1
-fi
+declare -A mysql_checks
+
+mysql_checks=( 
+  ["wsrep_cluster_status"]="Primary"
+  ["wsrep_ready"]="ON"
+  ["wsrep_local_state"]="4"
+  ["wsrep_connected"]="ON"
+)
+
+for check in "${!mysql_checks[@]}"; do
+  return_val=$(/usr/bin/mysql -h $3 -u root -p"$pass" -e "SELECT VARIABLE_NAME, VARIABLE_VALUE FROM information_schema.global_status WHERE VARIABLE_NAME = '$check';" -Ns)
+
+  if [ $? -ne 0 ]; then
+    echo Error: Unable to connect to MySQL or query failed
+    exit 1
+  else
+    strarray=($return_val) # convert string to array
+    if [ "${strarray[1]}" != "${mysql_checks[$check]}" ]; then
+      echo Error: "$check" is not "${mysql_checks[$check]}", actual status is: "${strarray[1]}"
+      exit 1
+    fi
+  fi
+done
 
 exit 0 

--- a/appuio/haproxy/templates/configmap-galera-checkscript.yaml
+++ b/appuio/haproxy/templates/configmap-galera-checkscript.yaml
@@ -2,22 +2,16 @@
 
 kind: ConfigMap
 apiVersion: v1
+metadata:
+  labels:
+    app.kubernetes.io/name: {{ include "haproxy.name" . }}
+    helm.sh/chart: {{ include "haproxy.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  name: haproxy-script
 data:
-  script.sh: |
-    #!/bin/bash
-    
-    # Run the MySQL query and store the result in a Bash variable
-    
-    wsrep_ready=$(/bin/cat /secrets/mariadb-root-password | /usr/bin/mysql-h $3 -u root -p -e SELECT VARIABLE_VALUE FROM information_schema.global_status WHERE VARIABLE_NAME = 'wsrep_ready'; -N)
-    if [ $? -ne 0 ]; then
-      echo Error: Unable to connect to MySQL or query failed
-      exit 1
-    fi
-    
-    if [ $wsrep_ready != "ON" ]; then
-      echo Error: wsrep_ready is not ON, actual status is: $WSREP_READY
-      exit 1
-    fi
-    
-    exit 0 
+  script.sh: |-
+    {{ range .Files.Lines "files/galera-check.sh" }}
+    {{ . | indent 2 }}
+    {{- end}}
 {{- end}}

--- a/appuio/haproxy/templates/configmap-galera-checkscript.yaml
+++ b/appuio/haproxy/templates/configmap-galera-checkscript.yaml
@@ -3,11 +3,21 @@
 kind: ConfigMap
 apiVersion: v1
 data:
-  script.sh: "#!/bin/bash\n\n# Run the MySQL query and store the result in a Bash
-    variable\nwsrep_ready=$(/bin/cat /secrets/mariadb-root-password | /usr/bin/mysql
-    -h $3 -u root -p -e \"SELECT VARIABLE_VALUE FROM information_schema.global_status
-    WHERE VARIABLE_NAME = 'wsrep_ready';\" -N)\nif [ \"$?\" -ne 0 ]; then\n  echo
-    \"Error: Unable to connect to MySQL or query failed\"\n  exit 1\nfi\n\nif [ \"$wsrep_ready\"
-    != \"ON\" ]; then\n  echo \"Error: wsrep_ready is not ON, actual status is: $WSREP_READY\"\n
-    \ exit 1\nfi\n\nexit 0 \n"
+  script.sh: |
+    #!/bin/bash
+    
+    # Run the MySQL query and store the result in a Bash variable
+    
+    wsrep_ready=$(/bin/cat /secrets/mariadb-root-password | /usr/bin/mysql-h $3 -u root -p -e SELECT VARIABLE_VALUE FROM information_schema.global_status WHERE VARIABLE_NAME = 'wsrep_ready'; -N)
+    if [ $? -ne 0 ]; then
+      echo Error: Unable to connect to MySQL or query failed
+      exit 1
+    fi
+    
+    if [ $wsrep_ready != "ON" ]; then
+      echo Error: wsrep_ready is not ON, actual status is: $WSREP_READY
+      exit 1
+    fi
+    
+    exit 0 
 {{- end}}

--- a/appuio/haproxy/templates/configmap-galera-checkscript.yaml
+++ b/appuio/haproxy/templates/configmap-galera-checkscript.yaml
@@ -1,0 +1,10 @@
+kind: ConfigMap
+apiVersion: v1
+data:
+  script.sh: "#!/bin/bash\n\n# Run the MySQL query and store the result in a Bash
+    variable\nwsrep_ready=$(/bin/cat /secrets/mariadb-root-password | /usr/bin/mysql
+    -h $3 -u root -p -e \"SELECT VARIABLE_VALUE FROM information_schema.global_status
+    WHERE VARIABLE_NAME = 'wsrep_ready';\" -N)\nif [ \"$?\" -ne 0 ]; then\n  echo
+    \"Error: Unable to connect to MySQL or query failed\"\n  exit 1\nfi\n\nif [ \"$wsrep_ready\"
+    != \"ON\" ]; then\n  echo \"Error: wsrep_ready is not ON, actual status is: $WSREP_READY\"\n
+    \ exit 1\nfi\n\nexit 0 \n"

--- a/appuio/haproxy/templates/configmap-galera-checkscript.yaml
+++ b/appuio/haproxy/templates/configmap-galera-checkscript.yaml
@@ -1,3 +1,5 @@
+{{- if or (eq .Values.haproxy.config "galera") (eq .Values.haproxy.config "galerak8s") }}
+
 kind: ConfigMap
 apiVersion: v1
 data:
@@ -8,3 +10,4 @@ data:
     \"Error: Unable to connect to MySQL or query failed\"\n  exit 1\nfi\n\nif [ \"$wsrep_ready\"
     != \"ON\" ]; then\n  echo \"Error: wsrep_ready is not ON, actual status is: $WSREP_READY\"\n
     \ exit 1\nfi\n\nexit 0 \n"
+{{- end}}

--- a/appuio/haproxy/templates/configmap-galera.yaml
+++ b/appuio/haproxy/templates/configmap-galera.yaml
@@ -45,6 +45,6 @@ data:
       {{ if and $galera.check.enabled $galera.check.mysql.enabled }}option mysql-check user {{ $galera.check.mysql.user }}{{ end }}
       default-server init-addr none {{ if $galera.check.enabled }}check {{ end }}resolvers mydns
       {{- range $index, $node := .Values.haproxy.galera.nodes }}
-      server node-{{ $index }} {{ $node.address }}:{{ default "3306" $node.port }} {{ if $node.backup }} backup{{ end }}
+      server node-{{ $index }} {{ $node.address }}:{{ default "3306" $node.port }}{{ if $node.backup }} backup{{ end }}
       {{- end }}
 {{- end }}

--- a/appuio/haproxy/templates/configmap-galera.yaml
+++ b/appuio/haproxy/templates/configmap-galera.yaml
@@ -12,7 +12,8 @@ metadata:
 data:
   haproxy.cfg: |
     global
-      tune.bufsize 300000 # 300k shoulb be fine, average prometheus response in 100 test queries was 244k
+      external-check # required for mysql-check
+      insecure-fork-wanted # required for mysql-check
       log stdout format raw local0
     {{- include "haproxy.resolversConfig" . | nindent 4 }}
 
@@ -38,12 +39,12 @@ data:
     backend galera-nodes
       mode tcp
       option srvtcpka
-      option httpchk GET /metrics 
-      http-check expect string mysql_global_status_wsrep_ready\ 1
+      option external-check
+      external-check command /var/lib/haproxy/script.sh
       balance {{ $galera.balance }}
       {{ if and $galera.check.enabled $galera.check.mysql.enabled }}option mysql-check user {{ $galera.check.mysql.user }}{{ end }}
       default-server init-addr none {{ if $galera.check.enabled }}check {{ end }}resolvers mydns
       {{- range $index, $node := .Values.haproxy.galera.nodes }}
-      server node-{{ $index }} {{ $node.address }}:{{ default "3306" $node.port }} check port 9104 {{ if $node.backup }} backup{{ end }}
+      server node-{{ $index }} {{ $node.address }}:{{ default "3306" $node.port }} {{ if $node.backup }} backup{{ end }}
       {{- end }}
 {{- end }}

--- a/appuio/haproxy/templates/configmap-galera.yaml
+++ b/appuio/haproxy/templates/configmap-galera.yaml
@@ -12,6 +12,7 @@ metadata:
 data:
   haproxy.cfg: |
     global
+      tune.bufsize 300000 # 300k shoulb be fine, average prometheus response in 100 test queries was 244k
       log stdout format raw local0
     {{- include "haproxy.resolversConfig" . | nindent 4 }}
 
@@ -37,10 +38,12 @@ data:
     backend galera-nodes
       mode tcp
       option srvtcpka
+      option httpchk GET /metrics 
+      http-check expect string mysql_global_status_wsrep_ready\ 1
       balance {{ $galera.balance }}
       {{ if and $galera.check.enabled $galera.check.mysql.enabled }}option mysql-check user {{ $galera.check.mysql.user }}{{ end }}
       default-server init-addr none {{ if $galera.check.enabled }}check {{ end }}resolvers mydns
       {{- range $index, $node := .Values.haproxy.galera.nodes }}
-      server node-{{ $index }} {{ $node.address }}:{{ default "3306" $node.port }}{{ if $node.backup }} backup{{ end }}
+      server node-{{ $index }} {{ $node.address }}:{{ default "3306" $node.port }} check port 9104 {{ if $node.backup }} backup{{ end }}
       {{- end }}
 {{- end }}

--- a/appuio/haproxy/templates/configmap-galerak8s.yaml
+++ b/appuio/haproxy/templates/configmap-galerak8s.yaml
@@ -13,6 +13,8 @@ data:
   haproxy.cfg: |
     global
       log stdout format raw local0
+      external-check # required for mysql-check
+      insecure-fork-wanted # required for mysql-check
     {{- include "haproxy.resolversConfig" . | nindent 4 }}
 
     defaults
@@ -37,6 +39,8 @@ data:
     backend galera-nodes
       mode tcp
       option srvtcpka
+      option external-check
+      external-check command /var/lib/haproxy/script.sh
       balance {{ $galera.balance }}
 
       {{ if and $galera.check.enabled $galera.check.mysql.enabled }}option mysql-check user {{ $galera.check.mysql.user }}{{ end }}

--- a/appuio/haproxy/templates/deployment.yaml
+++ b/appuio/haproxy/templates/deployment.yaml
@@ -71,6 +71,10 @@ spec:
           volumeMounts:
             - name: haproxy-config
               mountPath: /etc/haproxy/
+            - mountPath: /var/lib/haproxy
+              name: haproxy-script
+            - mountPath: /secrets
+              name: mariadb-creds
       {{- if .Values.sidecarContainers }}
 {{ tpl (toYaml .Values.sidecarContainers) . | indent 8 }}
       {{- end }}
@@ -78,6 +82,14 @@ spec:
         - name: haproxy-config
           configMap:
             name: "{{ include "haproxy.fullname" . }}-{{ .Values.haproxy.config }}"
+        - name: haproxy-script
+          configMap:
+            defaultMode: 511
+            name: haproxy-script
+        - name: mariadb-creds
+          secret:
+            secretName: mariadb
+            defaultMode: 420
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/appuio/haproxy/templates/deployment.yaml
+++ b/appuio/haproxy/templates/deployment.yaml
@@ -84,7 +84,8 @@ spec:
             name: "{{ include "haproxy.fullname" . }}-{{ .Values.haproxy.config }}"
         - name: haproxy-script
           configMap:
-            defaultMode: 511
+            # it's 0555 read+execute permissions
+            defaultMode: 365
             name: haproxy-script
         - name: mariadb-creds
           secret:

--- a/appuio/haproxy/templates/deployment.yaml
+++ b/appuio/haproxy/templates/deployment.yaml
@@ -71,10 +71,12 @@ spec:
           volumeMounts:
             - name: haproxy-config
               mountPath: /etc/haproxy/
+            {{- if or (eq .Values.haproxy.config "galera") (eq .Values.haproxy.config "galerak8s") }}
             - mountPath: /var/lib/haproxy
               name: haproxy-script
             - mountPath: /secrets
               name: mariadb-creds
+            {{ end }}
       {{- if .Values.sidecarContainers }}
 {{ tpl (toYaml .Values.sidecarContainers) . | indent 8 }}
       {{- end }}
@@ -82,6 +84,7 @@ spec:
         - name: haproxy-config
           configMap:
             name: "{{ include "haproxy.fullname" . }}-{{ .Values.haproxy.config }}"
+       {{- if or (eq .Values.haproxy.config "galera") (eq .Values.haproxy.config "galerak8s") }}
         - name: haproxy-script
           configMap:
             # it's 0555 read+execute permissions
@@ -91,6 +94,7 @@ spec:
           secret:
             secretName: mariadb
             defaultMode: 420
+        {{ end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/appuio/haproxy/values.yaml
+++ b/appuio/haproxy/values.yaml
@@ -37,7 +37,7 @@ service:
   additionalPorts: []
 
 haproxy:
-  config: ldap-tls
+  config: galerak8s
   frontendPort: 30636
 
   check:

--- a/appuio/haproxy/values.yaml
+++ b/appuio/haproxy/values.yaml
@@ -37,7 +37,7 @@ service:
   additionalPorts: []
 
 haproxy:
-  config: galerak8s
+  config: ldap-tls
   frontendPort: 30636
 
   check:

--- a/appuio/haproxy/values.yaml
+++ b/appuio/haproxy/values.yaml
@@ -1,9 +1,9 @@
 replicaCount: 1
 
 image:
-  registry: docker.io
-  repository: haproxytech/haproxy-debian
-  tag: 2.7.3
+  registry: ghcr-docker-remote.artifactory.swisscom.com
+  repository: vshn/haproxy-with-mysql
+  tag: 1.0.0
   pullPolicy: IfNotPresent
 
 ingress:

--- a/appuio/haproxy/values.yaml
+++ b/appuio/haproxy/values.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 image:
-  registry: ghcr-docker-remote.artifactory.swisscom.com
+  registry: ghcr.io
   repository: vshn/haproxy-with-mysql
   tag: 1.0.0
   pullPolicy: IfNotPresent


### PR DESCRIPTION
<!--
Thank you for contributing to appuio/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

-->

#### What this PR does / why we need it:

* This change ensures that Haproxy sends traffic only to nodes with wsred_ready=1 metric set. It queries prometheus endpoint and parses config. Buffer size for haproxy was raised from 16kB to 300kB, otherwise Haproxy can't "see" metrics. 

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] Chart Version bumped
- [x] I have run `make docs`
- [ ] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [ ] PR contains the label that identifies the chart, e.g. `chart/<chart-name>`
- [ ] PR contains the label that identifies the type of change, which is one of
      [ `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency` ]
