### PR TITLE
Adjust health check to return 503 if all backends are down

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ helm repo add appuio https://charts.appuio.ch
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/data-cube-curation-0.3.1/total)](https://github.com/appuio/charts/releases/tag/data-cube-curation-0.3.1) | [data-cube-curation](appuio/data-cube-curation/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/exoip-1.0.4/total)](https://github.com/appuio/charts/releases/tag/exoip-1.0.4) | [exoip](appuio/exoip/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/generic-0.1.2/total)](https://github.com/appuio/charts/releases/tag/generic-0.1.2) | [generic](appuio/generic/README.md) |
-| [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/haproxy-2.4.0/total)](https://github.com/appuio/charts/releases/tag/haproxy-2.4.0) | [haproxy](appuio/haproxy/README.md) |
+| [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/haproxy-2.5.0/total)](https://github.com/appuio/charts/releases/tag/haproxy-2.5.0) | [haproxy](appuio/haproxy/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/mariadb-galera-1.2.4/total)](https://github.com/appuio/charts/releases/tag/mariadb-galera-1.2.4) | [mariadb-galera](appuio/mariadb-galera/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/maxscale-2.0.1/total)](https://github.com/appuio/charts/releases/tag/maxscale-2.0.1) | [maxscale](appuio/maxscale/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/metrics-server-2.12.1/total)](https://github.com/appuio/charts/releases/tag/metrics-server-2.12.1) | [metrics-server](appuio/metrics-server/README.md) |

--- a/appuio/haproxy/Chart.yaml
+++ b/appuio/haproxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 2.7.3
 description: A Helm chart for HAProxy which can be customized by a config map.
 name: haproxy
-version: 2.4.0
+version: 2.5.0
 maintainers:
   - name: APPUiO Team
     email: info@appuio.ch

--- a/appuio/haproxy/README.md
+++ b/appuio/haproxy/README.md
@@ -1,6 +1,6 @@
 # haproxy
 
-![Version: 2.4.0](https://img.shields.io/badge/Version-2.4.0-informational?style=flat-square) ![AppVersion: 2.7.3](https://img.shields.io/badge/AppVersion-2.7.3-informational?style=flat-square)
+![Version: 2.5.0](https://img.shields.io/badge/Version-2.5.0-informational?style=flat-square) ![AppVersion: 2.7.3](https://img.shields.io/badge/AppVersion-2.7.3-informational?style=flat-square)
 
 A Helm chart for HAProxy which can be customized by a config map.
 


### PR DESCRIPTION
<!--
Thank you for contributing to appuio/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

-->

#### What this PR does / why we need it:

If all backends are down, the haproxy instance should not be served anymore by kubernetes and the readiness probe should fail. Furthermore, we also fail the liveness probe to enforce a restart of haproxy, as this can resolve the issue in some cases (eg. network or dns issues).


#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] Chart Version bumped
- [x] I have run `make docs`
- [ ] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] PR contains the label that identifies the chart, e.g. `chart/<chart-name>`
- [x] PR contains the label that identifies the type of change, which is one of
      [ `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency` ]
