### PR TITLE
Add template for HttpCheck alert configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ helm repo add appuio https://charts.appuio.ch
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/secret-1.1.0/total)](https://github.com/appuio/charts/releases/tag/secret-1.1.0) | [secret](appuio/secret/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/signalilo-0.12.1/total)](https://github.com/appuio/charts/releases/tag/signalilo-0.12.1) | [signalilo](appuio/signalilo/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/snappass-1.0.0/total)](https://github.com/appuio/charts/releases/tag/snappass-1.0.0) | [snappass](appuio/snappass/README.md) |
-| [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/stardog-0.23.1/total)](https://github.com/appuio/charts/releases/tag/stardog-0.23.1) | [stardog](appuio/stardog/README.md) |
+| [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/stardog-0.24.0/total)](https://github.com/appuio/charts/releases/tag/stardog-0.24.0) | [stardog](appuio/stardog/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/stardog-userrole-operator-0.2.3/total)](https://github.com/appuio/charts/releases/tag/stardog-userrole-operator-0.2.3) | [stardog-userrole-operator](appuio/stardog-userrole-operator/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/trifid-2.0.2/total)](https://github.com/appuio/charts/releases/tag/trifid-2.0.2) | [trifid](appuio/trifid/README.md) |
 

--- a/appuio/stardog/Chart.yaml
+++ b/appuio/stardog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: stardog
-version: 0.23.1
+version: 0.24.0
 appVersion: 9.2.1
 description: Stardog is the world’s leading knowledge graph platform for the enterprise. Stardog makes it fast and easy to turn enterprise data into knowledge.
 home: "https://www.stardog.com/"

--- a/appuio/stardog/README.md
+++ b/appuio/stardog/README.md
@@ -1,6 +1,6 @@
 # stardog
 
-![Version: 0.23.1](https://img.shields.io/badge/Version-0.23.1-informational?style=flat-square) ![AppVersion: 9.2.1](https://img.shields.io/badge/AppVersion-9.2.1-informational?style=flat-square)
+![Version: 0.24.0](https://img.shields.io/badge/Version-0.24.0-informational?style=flat-square) ![AppVersion: 9.2.1](https://img.shields.io/badge/AppVersion-9.2.1-informational?style=flat-square)
 
 Stardog is the world’s leading knowledge graph platform for the enterprise. Stardog makes it fast and easy to turn enterprise data into knowledge.
 

--- a/appuio/stardog/templates/monitoring/stardog-rules.yaml
+++ b/appuio/stardog/templates/monitoring/stardog-rules.yaml
@@ -48,7 +48,7 @@ spec:
     {{- if .Values.ingress.enabled }}
     - alert: HttpCheck
       expr: probe_success{instance="https://{{ .Values.ingress.host }}/admin/healthcheck"} != 1
-      for: {{ (((.Values.alerts).httpCheck).for) | default 1m | quote }}
+      for: {{ (((.Values.alerts).httpCheck).for) | default 1m }}
       annotations:
         summary: Http check failed
         description: "Http check failed on {{ "{{" }} $labels.instance {{ "}}" }}"

--- a/appuio/stardog/templates/monitoring/stardog-rules.yaml
+++ b/appuio/stardog/templates/monitoring/stardog-rules.yaml
@@ -48,7 +48,7 @@ spec:
     {{- if .Values.ingress.enabled }}
     - alert: HttpCheck
       expr: probe_success{instance="https://{{ .Values.ingress.host }}/admin/healthcheck"} != 1
-      for: {{ (((.Values.alerts).httpCheck).for) | default 1m }}
+      for: "{{ (((.Values.alerts).httpCheck).for) | default 1m }}"
       annotations:
         summary: Http check failed
         description: "Http check failed on {{ "{{" }} $labels.instance {{ "}}" }}"

--- a/appuio/stardog/templates/monitoring/stardog-rules.yaml
+++ b/appuio/stardog/templates/monitoring/stardog-rules.yaml
@@ -48,7 +48,7 @@ spec:
     {{- if .Values.ingress.enabled }}
     - alert: HttpCheck
       expr: probe_success{instance="https://{{ .Values.ingress.host }}/admin/healthcheck"} != 1
-      for: "{{ "{{ if (((.Values.alerts).httpCheck).for) }}" }}{{ .Values.alerts.httpCheck.for }}{{ "{{ else }}" }}1m{{ "{{ end }}" }}"
+      for: {{ default "1m" .Values.alerts.httpCheck.for | quote }}
       annotations:
         summary: Http check failed
         description: "Http check failed on {{ "{{" }} $labels.instance {{ "}}" }}"

--- a/appuio/stardog/templates/monitoring/stardog-rules.yaml
+++ b/appuio/stardog/templates/monitoring/stardog-rules.yaml
@@ -48,7 +48,7 @@ spec:
     {{- if .Values.ingress.enabled }}
     - alert: HttpCheck
       expr: probe_success{instance="https://{{ .Values.ingress.host }}/admin/healthcheck"} != 1
-      for: {{ (((.Values.alerts).httpCheck).for) | default 1m }}
+      for: "{{ "{{ if (((.Values.alerts).httpCheck).for) }}" }}{{ .Values.alerts.httpCheck.for }}{{ "{{ else }}" }}1m{{ "{{ end }}" }}"
       annotations:
         summary: Http check failed
         description: "Http check failed on {{ "{{" }} $labels.instance {{ "}}" }}"

--- a/appuio/stardog/templates/monitoring/stardog-rules.yaml
+++ b/appuio/stardog/templates/monitoring/stardog-rules.yaml
@@ -48,7 +48,7 @@ spec:
     {{- if .Values.ingress.enabled }}
     - alert: HttpCheck
       expr: probe_success{instance="https://{{ .Values.ingress.host }}/admin/healthcheck"} != 1
-      for: 1m
+      for: {{ .Values.alerts.httpCheck.for | default 1m | quote }}
       annotations:
         summary: Http check failed
         description: "Http check failed on {{ "{{" }} $labels.instance {{ "}}" }}"

--- a/appuio/stardog/templates/monitoring/stardog-rules.yaml
+++ b/appuio/stardog/templates/monitoring/stardog-rules.yaml
@@ -48,7 +48,7 @@ spec:
     {{- if .Values.ingress.enabled }}
     - alert: HttpCheck
       expr: probe_success{instance="https://{{ .Values.ingress.host }}/admin/healthcheck"} != 1
-      for: "{{ (((.Values.alerts).httpCheck).for) | default 1m }}"
+      for: {{ (((.Values.alerts).httpCheck).for) | default 1m }}
       annotations:
         summary: Http check failed
         description: "Http check failed on {{ "{{" }} $labels.instance {{ "}}" }}"

--- a/appuio/stardog/templates/monitoring/stardog-rules.yaml
+++ b/appuio/stardog/templates/monitoring/stardog-rules.yaml
@@ -48,7 +48,7 @@ spec:
     {{- if .Values.ingress.enabled }}
     - alert: HttpCheck
       expr: probe_success{instance="https://{{ .Values.ingress.host }}/admin/healthcheck"} != 1
-      for: {{ .Values.alerts.httpCheck.for | default 1m | quote }}
+      for: {{ (((.Values.alerts).httpCheck).for) | default 1m | quote }}
       annotations:
         summary: Http check failed
         description: "Http check failed on {{ "{{" }} $labels.instance {{ "}}" }}"

--- a/appuio/stardog/templates/monitoring/stardog-rules.yaml
+++ b/appuio/stardog/templates/monitoring/stardog-rules.yaml
@@ -48,7 +48,7 @@ spec:
     {{- if .Values.ingress.enabled }}
     - alert: HttpCheck
       expr: probe_success{instance="https://{{ .Values.ingress.host }}/admin/healthcheck"} != 1
-      for: {{ default "1m" .Values.alerts.httpCheck.for | quote }}
+      for: {{ default "1m" (((.Values.alerts).httpCheck).for) | quote }}
       annotations:
         summary: Http check failed
         description: "Http check failed on {{ "{{" }} $labels.instance {{ "}}" }}"

--- a/appuio/stardog/values.yaml
+++ b/appuio/stardog/values.yaml
@@ -94,7 +94,7 @@ metrics:
     pullPolicy: IfNotPresent
 alerts:
   httpCheck:
-    for: 1m
+    for:
 resources: {}
 
 nodeSelector: {}

--- a/appuio/stardog/values.yaml
+++ b/appuio/stardog/values.yaml
@@ -94,7 +94,7 @@ metrics:
     pullPolicy: IfNotPresent
 alerts:
   httpCheck:
-    for: 30m
+    for: 1m
 resources: {}
 
 nodeSelector: {}

--- a/appuio/stardog/values.yaml
+++ b/appuio/stardog/values.yaml
@@ -92,7 +92,9 @@ metrics:
     repository: sscaling/jmx-prometheus-exporter
     tag: 0.12.0
     pullPolicy: IfNotPresent
-
+alerts:
+  httpCheck:
+    for: 30m
 resources: {}
 
 nodeSelector: {}


### PR DESCRIPTION
<!--
Thank you for contributing to appuio/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

-->

#### What this PR does / why we need it:

* Adds a helm template to configure the 'for' key of stardog HttpCheck alerts.

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] Chart Version bumped
- [x] I have run `make docs`
- [x] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] PR contains the label that identifies the chart, e.g. `chart/<chart-name>`
- [x] PR contains the label that identifies the type of change, which is one of
      [ `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency` ]
