### PR TITLE
stardog: Unset custom scrape interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ helm repo add appuio https://charts.appuio.ch
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/secret-1.1.0/total)](https://github.com/appuio/charts/releases/tag/secret-1.1.0) | [secret](appuio/secret/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/signalilo-0.12.1/total)](https://github.com/appuio/charts/releases/tag/signalilo-0.12.1) | [signalilo](appuio/signalilo/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/snappass-1.0.0/total)](https://github.com/appuio/charts/releases/tag/snappass-1.0.0) | [snappass](appuio/snappass/README.md) |
-| [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/stardog-0.25.0/total)](https://github.com/appuio/charts/releases/tag/stardog-0.25.0) | [stardog](appuio/stardog/README.md) |
+| [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/stardog-0.26.0/total)](https://github.com/appuio/charts/releases/tag/stardog-0.26.0) | [stardog](appuio/stardog/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/stardog-userrole-operator-0.2.3/total)](https://github.com/appuio/charts/releases/tag/stardog-userrole-operator-0.2.3) | [stardog-userrole-operator](appuio/stardog-userrole-operator/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/trifid-2.0.2/total)](https://github.com/appuio/charts/releases/tag/trifid-2.0.2) | [trifid](appuio/trifid/README.md) |
 

--- a/appuio/stardog/Chart.yaml
+++ b/appuio/stardog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: stardog
-version: 0.25.0
+version: 0.26.0
 appVersion: 10.0.1
 description: Stardog is the world’s leading knowledge graph platform for the enterprise. Stardog makes it fast and easy to turn enterprise data into knowledge.
 home: "https://www.stardog.com/"

--- a/appuio/stardog/README.gotmpl.md
+++ b/appuio/stardog/README.gotmpl.md
@@ -64,8 +64,10 @@ The following table lists the configurable parameters chart. For default values 
 | `ingress.host`                               | Host name which the ingress should resolve |
 | `ingress.tls.enabled`                        | If TLS should be enabled on the ingress |
 | `ingress.tls.secretName`                     | Name of the secret containing the TLS certificate and key |
-| `metrics.stardogRules.extraLabels`        | A hash of labels to add to Stardog's PrometheusRules |
-| `metrics.zookeeperRules.extraLabels`        | A hash of labels to add to ZooKeeper's PrometheusRules |
+| `metrics.stardogRules.extraLabels`           | A hash of labels to add to Stardog's PrometheusRules |
+| `metrics.zookeeperRules.extraLabels`         | A hash of labels to add to ZooKeeper's PrometheusRules |
+| `metrics.serviceMonitor.interval`            | Overwrite Prometheus' default scrape interval for the Stardog ServiceMonitor |
+| `metrics.serviceMonitor.timeout`             | Overwrite Prometheus' default scrape timeout for the Stardog ServiceMonitor |
 | `persistence.enabled`                        | Enable persistence using PVC |
 | `persistence.storageClass`                   | PVC storage class for Stardog data volume |
 | `persistence.size`                           | PVC storage request size for Stardog data volume |

--- a/appuio/stardog/README.md
+++ b/appuio/stardog/README.md
@@ -1,6 +1,6 @@
 # stardog
 
-![Version: 0.25.0](https://img.shields.io/badge/Version-0.25.0-informational?style=flat-square) ![AppVersion: 10.0.1](https://img.shields.io/badge/AppVersion-10.0.1-informational?style=flat-square)
+![Version: 0.26.0](https://img.shields.io/badge/Version-0.26.0-informational?style=flat-square) ![AppVersion: 10.0.1](https://img.shields.io/badge/AppVersion-10.0.1-informational?style=flat-square)
 
 Stardog is the world’s leading knowledge graph platform for the enterprise. Stardog makes it fast and easy to turn enterprise data into knowledge.
 
@@ -78,8 +78,10 @@ The following table lists the configurable parameters chart. For default values 
 | `ingress.host`                               | Host name which the ingress should resolve |
 | `ingress.tls.enabled`                        | If TLS should be enabled on the ingress |
 | `ingress.tls.secretName`                     | Name of the secret containing the TLS certificate and key |
-| `metrics.stardogRules.extraLabels`        | A hash of labels to add to Stardog's PrometheusRules |
-| `metrics.zookeeperRules.extraLabels`        | A hash of labels to add to ZooKeeper's PrometheusRules |
+| `metrics.stardogRules.extraLabels`           | A hash of labels to add to Stardog's PrometheusRules |
+| `metrics.zookeeperRules.extraLabels`         | A hash of labels to add to ZooKeeper's PrometheusRules |
+| `metrics.serviceMonitor.interval`            | Overwrite Prometheus' default scrape interval for the Stardog ServiceMonitor |
+| `metrics.serviceMonitor.timeout`             | Overwrite Prometheus' default scrape timeout for the Stardog ServiceMonitor |
 | `persistence.enabled`                        | Enable persistence using PVC |
 | `persistence.storageClass`                   | PVC storage class for Stardog data volume |
 | `persistence.size`                           | PVC storage request size for Stardog data volume |

--- a/appuio/stardog/templates/monitoring/stardog-servicemonitor.yaml
+++ b/appuio/stardog/templates/monitoring/stardog-servicemonitor.yaml
@@ -21,10 +21,14 @@ spec:
         # unless there is a cleaner way of doing this, the name "admin" must be stored in a secret:
         name: {{ template "stardog.fullname" . }}-admin-username
         key: adminusername
-    interval: 3s
+    {{- if .Values.metrics.serviceMonitor.interval }}
+    interval: {{ quote .Values.metrics.serviceMonitor.interval }}
+    {{- end }}
     path: /admin/status/prometheus
     port: stardog
-    scrapeTimeout: 3s
+    {{- if .Values.metrics.serviceMonitor.timeout }}
+    scrapeTimeout: {{ quote .Values.metrics.serviceMonitor.timeout }}
+    {{- end }}
   jobLabel: app.kubernetes.io/instance
   podTargetLabels:
     - app.kubernetes.io/component

--- a/appuio/stardog/values.yaml
+++ b/appuio/stardog/values.yaml
@@ -83,6 +83,11 @@ persistence:
 metrics:
   enabled: false
   prometheusOperator: false
+  serviceMonitor:
+    # Scrape interval and timeout.
+    # Interval may not be smaller than timeout.
+    # interval: 10s
+    # timeout: 10s
   stardogRules:
     extraLabels: null
   zookeeperRules:
@@ -92,6 +97,7 @@ metrics:
     repository: sscaling/jmx-prometheus-exporter
     tag: 0.12.0
     pullPolicy: IfNotPresent
+
 alerts:
   httpCheck:
     for:


### PR DESCRIPTION
#### What this PR does / why we need it:
The current interval of 3s is quite idiotic; there is no real value in scraping data every 3 seconds if in the end you're more interested in data over a day or so.

This commit
- removes the value by default, which will cause the scrapeconfig to use the default value configured in Prometheus' global config
- allows us to overwrite the interval and timeouts via values

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] Chart Version bumped
- [x] I have run `make docs`
- [x] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] PR contains the label that identifies the chart, e.g. `chart/<chart-name>`
- [x] PR contains the label that identifies the type of change, which is one of
      [ `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency` ]
