### PR TITLE
Fix missing configuration for mariadb-operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ helm repo add appuio https://charts.appuio.ch
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/data-cube-curation-0.3.1/total)](https://github.com/appuio/charts/releases/tag/data-cube-curation-0.3.1) | [data-cube-curation](appuio/data-cube-curation/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/exoip-1.0.4/total)](https://github.com/appuio/charts/releases/tag/exoip-1.0.4) | [exoip](appuio/exoip/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/generic-0.1.2/total)](https://github.com/appuio/charts/releases/tag/generic-0.1.2) | [generic](appuio/generic/README.md) |
-| [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/haproxy-2.7.0/total)](https://github.com/appuio/charts/releases/tag/haproxy-2.7.0) | [haproxy](appuio/haproxy/README.md) |
+| [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/haproxy-2.7.1/total)](https://github.com/appuio/charts/releases/tag/haproxy-2.7.1) | [haproxy](appuio/haproxy/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/mariadb-galera-1.2.6/total)](https://github.com/appuio/charts/releases/tag/mariadb-galera-1.2.6) | [mariadb-galera](appuio/mariadb-galera/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/maxscale-2.0.1/total)](https://github.com/appuio/charts/releases/tag/maxscale-2.0.1) | [maxscale](appuio/maxscale/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/metrics-server-2.12.1/total)](https://github.com/appuio/charts/releases/tag/metrics-server-2.12.1) | [metrics-server](appuio/metrics-server/README.md) |

--- a/appuio/haproxy/Chart.yaml
+++ b/appuio/haproxy/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 2.7.3
 description: A Helm chart for HAProxy which can be customized by a config map.
 name: haproxy
-version: 2.7.0
+version: 2.7.1
 maintainers:
   - name: APPUiO Team
     email: info@appuio.ch

--- a/appuio/haproxy/README.md
+++ b/appuio/haproxy/README.md
@@ -1,6 +1,6 @@
 # haproxy
 
-![Version: 2.7.0](https://img.shields.io/badge/Version-2.7.0-informational?style=flat-square) ![AppVersion: 2.7.3](https://img.shields.io/badge/AppVersion-2.7.3-informational?style=flat-square)
+![Version: 2.7.1](https://img.shields.io/badge/Version-2.7.1-informational?style=flat-square) ![AppVersion: 2.7.3](https://img.shields.io/badge/AppVersion-2.7.3-informational?style=flat-square)
 
 A Helm chart for HAProxy which can be customized by a config map.
 

--- a/appuio/haproxy/templates/configmap-galera-checkscript.yaml
+++ b/appuio/haproxy/templates/configmap-galera-checkscript.yaml
@@ -1,4 +1,4 @@
-{{- if or (eq .Values.haproxy.config "galera") (eq .Values.haproxy.config "galerak8s") }}
+{{- if or (eq .Values.haproxy.config "galera") (eq .Values.haproxy.config "galerak8s") (eq .Values.haproxy.config "mariadb-operator") }}
 
 kind: ConfigMap
 apiVersion: v1

--- a/appuio/haproxy/templates/configmap-mariadb-operator.yaml
+++ b/appuio/haproxy/templates/configmap-mariadb-operator.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: "{{ include "haproxy.fullname" . }}-galera"
+  name: "{{ include "haproxy.fullname" . }}-mariadb-operator"
   labels:
     app.kubernetes.io/name: {{ include "haproxy.name" . }}
     helm.sh/chart: {{ include "haproxy.chart" . }}

--- a/appuio/haproxy/templates/deployment.yaml
+++ b/appuio/haproxy/templates/deployment.yaml
@@ -40,7 +40,7 @@ spec:
             - name: metrics
               containerPort: 9000
             {{- end }}
-            {{- if or .Values.haproxy.redisk8s.metrics.enabled .Values.haproxy.galerak8s.metrics.enabled .Values.haproxy.galera.metrics.enabled}}
+            {{- if or .Values.haproxy.redisk8s.metrics.enabled .Values.haproxy.galerak8s.metrics.enabled .Values.haproxy.galera.metrics.enabled .Values.haproxy.mariadbOperator.metrics.enabled}}
             - name: metrics-backend
               containerPort: 9090
             {{- end }}
@@ -71,7 +71,7 @@ spec:
           volumeMounts:
             - name: haproxy-config
               mountPath: /etc/haproxy/
-            {{- if or (eq .Values.haproxy.config "galera") (eq .Values.haproxy.config "galerak8s") }}
+            {{- if or (eq .Values.haproxy.config "galera") (eq .Values.haproxy.config "galerak8s") (eq .Values.haproxy.config "mariadb-operator") }}
             - mountPath: /var/lib/haproxy
               name: haproxy-script
             - mountPath: /secrets
@@ -84,7 +84,7 @@ spec:
         - name: haproxy-config
           configMap:
             name: "{{ include "haproxy.fullname" . }}-{{ .Values.haproxy.config }}"
-       {{- if or (eq .Values.haproxy.config "galera") (eq .Values.haproxy.config "galerak8s") }}
+       {{- if or (eq .Values.haproxy.config "galera") (eq .Values.haproxy.config "galerak8s") (eq .Values.haproxy.config "mariadb-operator") }}
         - name: haproxy-script
           configMap:
             # it's 0555 read+execute permissions


### PR DESCRIPTION
<!--
Thank you for contributing to appuio/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

-->

#### What this PR does / why we need it:

* Fix missing configurations for the mariadb-operator configuration

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] Chart Version bumped
- [x] I have run `make docs`
- [x] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).
- [x] PR contains the label that identifies the chart, e.g. `chart/<chart-name>`
- [x] PR contains the label that identifies the type of change, which is one of
      [ `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency` ]
