### PR TITLE
stardog: allow to configure additionalLabels for alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ helm repo add appuio https://charts.appuio.ch
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/secret-1.1.0/total)](https://github.com/appuio/charts/releases/tag/secret-1.1.0) | [secret](appuio/secret/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/signalilo-0.12.1/total)](https://github.com/appuio/charts/releases/tag/signalilo-0.12.1) | [signalilo](appuio/signalilo/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/snappass-1.0.0/total)](https://github.com/appuio/charts/releases/tag/snappass-1.0.0) | [snappass](appuio/snappass/README.md) |
-| [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/stardog-0.26.11/total)](https://github.com/appuio/charts/releases/tag/stardog-0.26.11) | [stardog](appuio/stardog/README.md) |
+| [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/stardog-0.26.12/total)](https://github.com/appuio/charts/releases/tag/stardog-0.26.12) | [stardog](appuio/stardog/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/stardog-userrole-operator-0.4.0/total)](https://github.com/appuio/charts/releases/tag/stardog-userrole-operator-0.4.0) | [stardog-userrole-operator](appuio/stardog-userrole-operator/README.md) |
 | [![chart downloads](https://img.shields.io/github/downloads/appuio/charts/trifid-2.0.2/total)](https://github.com/appuio/charts/releases/tag/trifid-2.0.2) | [trifid](appuio/trifid/README.md) |
 

--- a/appuio/stardog/Chart.yaml
+++ b/appuio/stardog/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: stardog
-version: 0.26.11
+version: 0.26.12
 appVersion: 10.1.0
 description: Stardog is the world’s leading knowledge graph platform for the enterprise. Stardog makes it fast and easy to turn enterprise data into knowledge.
 home: "https://www.stardog.com/"

--- a/appuio/stardog/README.md
+++ b/appuio/stardog/README.md
@@ -1,6 +1,6 @@
 # stardog
 
-![Version: 0.26.11](https://img.shields.io/badge/Version-0.26.11-informational?style=flat-square) ![AppVersion: 10.1.0](https://img.shields.io/badge/AppVersion-10.1.0-informational?style=flat-square)
+![Version: 0.26.12](https://img.shields.io/badge/Version-0.26.12-informational?style=flat-square) ![AppVersion: 10.1.0](https://img.shields.io/badge/AppVersion-10.1.0-informational?style=flat-square)
 
 Stardog is the world’s leading knowledge graph platform for the enterprise. Stardog makes it fast and easy to turn enterprise data into knowledge.
 

--- a/appuio/stardog/templates/monitoring/stardog-java-rules.yaml
+++ b/appuio/stardog/templates/monitoring/stardog-java-rules.yaml
@@ -17,7 +17,12 @@ spec:
     rules:
       - alert: JavaLowHeapMemory
         expr: dbms_memory_heap_max{ {{ $ns_selector }} } - dbms_memory_heap_used{ {{ $ns_selector }} } < 128 * 1024 * 1024
-        for: 1m
+        {{- with .Values.alerts.javaLowHeapMemory }}
+        for: {{ default "1m" .for | quote }}
+        {{- if .keep_firing_for }}
+        keep_firing_for: {{ .keep_firing_for | quote }}
+        {{- end }}
+        {{- end }}
         annotations:
           summary: Java Low Heap Memory
           description: Less than 128M of heap memory is available ({{ "{{" }} $value {{ "}}" }}).
@@ -25,4 +30,7 @@ spec:
           env: {{ .Release.Name }}
           app: stardog
           severity: warning
+          {{- range $key,$value := .Values.alerts.javaLowHeapMemory.additionalLabels }}
+          {{ $key }}: {{ $value | quote }}
+          {{- end }}
 {{- end }}

--- a/appuio/stardog/templates/monitoring/stardog-rules.yaml
+++ b/appuio/stardog/templates/monitoring/stardog-rules.yaml
@@ -30,6 +30,9 @@ spec:
         env: {{ .Release.Name }}
         app: stardog
         severity: critical
+        {{- range $key,$value := .Values.alerts.stardogOpenConnections.additionalLabels }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
     - alert: StardogLicenseExpire
       expr: min(dbms_license_expiration{ {{ $ns_selector }} }) without (instance, pod) < 42
       {{- with .Values.alerts.stardogLicenseExpire }}
@@ -45,6 +48,9 @@ spec:
         env: {{ .Release.Name }}
         app: stardog
         severity: "{{ "{{ if lt $value 21.0 }}" }}critical{{ "{{ else }}" }}warning{{ "{{ end }}" }}"
+        {{- range $key,$value := .Values.alerts.stardogLicenseExpire.additionalLabels }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
     - alert: StardogPodsNotReady
       expr: kube_statefulset_status_replicas_ready{ {{ $ns_selector }}, statefulset="{{ include "stardog.fullname" . }}" } != {{ .Values.replicaCount }}
       {{- with .Values.alerts.stardogPodsNotReady }}
@@ -60,6 +66,9 @@ spec:
         env: {{ .Release.Name }}
         app: stardog
         severity: "{{ "{{ if lt $value 2.0 }}" }}critical{{ "{{ else }}" }}warning{{ "{{ end }}" }}"
+        {{- range $key,$value := .Values.alerts.stardogPodsNotReady.additionalLabels }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
     {{- if .Values.ingress.enabled }}
     - alert: HttpCheck
       expr: probe_success{instance="https://{{ .Values.ingress.host }}/admin/healthcheck"} != 1
@@ -76,6 +85,9 @@ spec:
         env: {{ .Release.Name }}
         severity: critical
         oncall: "{{ "{{ if eq $labels.env \\\"prod\\\" }}" }}true{{ "{{ else }}" }}false{{" {{ end }} "}}"
+        {{- range $key,$value := .Values.alerts.httpCheck.additionalLabels }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
     - alert: CertExpirySoon
       expr: probe_ssl_earliest_cert_expiry{instance="https://{{ .Values.ingress.host }}/admin/healthcheck"} - time() < 86400 * 30
       {{- with .Values.alerts.certExpirySoon }}
@@ -90,5 +102,8 @@ spec:
       labels:
         env: {{ .Release.Name }}
         severity: warning
+        {{- range $key,$value := .Values.alerts.certExpirySoon.additionalLabels }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
     {{- end }}
 {{- end }}

--- a/appuio/stardog/templates/monitoring/zookeeper-rules.yaml
+++ b/appuio/stardog/templates/monitoring/zookeeper-rules.yaml
@@ -17,7 +17,12 @@ spec:
     rules:
     - alert: ZooKeeperPodsNotReady
       expr: kube_statefulset_status_replicas_ready{ {{ $ns_selector }}, statefulset="{{ include "stardog.zookeeper.fullname" . }}" } != {{ .Values.zookeeper.replicaCount }}
-      for: 10m
+      {{- with .Values.alerts.zooKeeperPodsNotReady }}
+      for: {{ default "10m" .for | quote }}
+      {{- if .keep_firing_for }}
+      keep_firing_for: {{ .keep_firing_for | quote }}
+      {{- end }}
+      {{- end }}
       annotations:
         summary: Pods of ZooKeeper StatefulSet not ready
         description: Only {{ "{{" }} $value {{ "}}" }} of {{ .Values.zookeeper.replicaCount }} ZooKeeper pods are ready in namespace {{ "{{" }} $labels.namespace {{ "}}" }}.
@@ -25,4 +30,7 @@ spec:
         env: {{ .Release.Name }}
         app: zookeeper
         severity: "{{ "{{ if lt $value 2.0 }}" }}critical{{ "{{ else }}" }}warning{{ "{{ end }}" }}"
+        {{- range $key,$value := .Values.alerts.zooKeeperPodsNotReady.additionalLabels }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
 {{- end }}

--- a/appuio/stardog/test/smoke_test.go
+++ b/appuio/stardog/test/smoke_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/stretchr/testify/assert"
 )
@@ -15,7 +16,7 @@ func Test_Chart_can_be_rendered(t *testing.T) {
 		SetValues: minimalOptionsForAllTemplates,
 	}
 
-	err := renderChart(t, options)
+	_, err := renderChart(t, options)
 
 	assert.Nil(t, err)
 }
@@ -27,12 +28,42 @@ func Test_Chart_can_be_rendered_with_keep_firing_for(t *testing.T) {
 		}),
 	}
 
-	err := renderChart(t, options)
+	_, err := renderChart(t, options)
 
 	assert.Nil(t, err)
 }
 
-func renderChart(t *testing.T, options *helm.Options) error {
+func Test_Chart_can_be_rendered_with_additional_labels_for_alerts(t *testing.T) {
+	test1Value := uuid.NewString()
+	test2Value := uuid.NewString()
+	options := &helm.Options{
+		SetValues: Merge(minimalOptionsForAllTemplates, map[string]string{
+			"alerts.javaLowHeapMemory.additionalLabels.test1":      test1Value,
+			"alerts.javaLowHeapMemory.additionalLabels.test2":      test2Value,
+			"alerts.stardogOpenConnections.additionalLabels.test1": test1Value,
+			"alerts.stardogOpenConnections.additionalLabels.test2": test2Value,
+			"alerts.stardogLicenseExpire.additionalLabels.test1":   test1Value,
+			"alerts.stardogLicenseExpire.additionalLabels.test2":   test2Value,
+			"alerts.stardogPodsNotReady.additionalLabels.test1":    test1Value,
+			"alerts.stardogPodsNotReady.additionalLabels.test2":    test2Value,
+			"alerts.httpCheck.additionalLabels.test1":              test1Value,
+			"alerts.httpCheck.additionalLabels.test2":              test2Value,
+			"alerts.certExpirySoon.additionalLabels.test1":         test1Value,
+			"alerts.certExpirySoon.additionalLabels.test2":         test2Value,
+			"alerts.zooKeeperPodsNotReady.additionalLabels.test1":  test1Value,
+			"alerts.zooKeeperPodsNotReady.additionalLabels.test2":  test2Value,
+		}),
+	}
+
+	result, err := renderChart(t, options)
+
+	assert.Nil(t, err)
+
+	assert.Equalf(t, 7, strings.Count(result, "\""+test1Value+"\""), "Expected to to have test1Value a correct amount of times")
+	assert.Equalf(t, 7, strings.Count(result, "\""+test2Value+"\""), "Expected to to have test2Value a correct amount of times")
+}
+
+func renderChart(t *testing.T, options *helm.Options) (string, error) {
 	helmChartPathAbsPath, err := filepath.Abs(helmChartPath)
 	if err != nil {
 		t.Fatal(err)
@@ -42,8 +73,8 @@ func renderChart(t *testing.T, options *helm.Options) error {
 		t.Fatal(err)
 	}
 
-	_, err = helm.RenderTemplateE(t, options, helmChartPath, releaseName, files)
-	return err
+	result, renderErr := helm.RenderTemplateE(t, options, helmChartPath, releaseName, files)
+	return result, renderErr
 }
 
 func findYamlFiles(root string, relativeTo string) ([]string, error) {

--- a/appuio/stardog/values.yaml
+++ b/appuio/stardog/values.yaml
@@ -100,21 +100,34 @@ metrics:
     pullPolicy: IfNotPresent
 
 alerts:
+  javaLowHeapMemory:
+    for:
+    keep_firing_for:
+    additionalLabels: {}
   stardogOpenConnections:
     for:
     keep_firing_for:
+    additionalLabels: {}
   stardogLicenseExpire:
     for:
     keep_firing_for:
+    additionalLabels: {}
   stardogPodsNotReady:
     for:
     keep_firing_for:
+    additionalLabels: {}
   httpCheck:
     for:
     keep_firing_for:
+    additionalLabels: {}
   certExpirySoon:
     for:
     keep_firing_for:
+    additionalLabels: {}
+  zooKeeperPodsNotReady:
+    for:
+    keep_firing_for:
+    additionalLabels: {}
 resources: {}
 
 nodeSelector: {}


### PR DESCRIPTION
On OKE clusters there is no user workload monitoring. So we need to misuse the cluster monitoring.

Issue: SBAR-1443

<!--
Thank you for contributing to appuio/charts. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

-->

#### What this PR does / why we need it:

* Short summary

#### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
- [x] Chart Version bumped
- [x] I have run `make docs`
~~- [ ] Variables are documented in the values.yaml using the format required by [Helm-Docs](https://github.com/norwoodj/helm-docs#valuesyaml-metadata).~~
- [x] PR contains the label that identifies the chart, e.g. `chart/<chart-name>`
- [x] PR contains the label that identifies the type of change, which is one of
      [ `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency` ]
